### PR TITLE
Add animated atom background to admin layout

### DIFF
--- a/admin/sysgd-admin/src/components/layouts/AdminLayout.tsx
+++ b/admin/sysgd-admin/src/components/layouts/AdminLayout.tsx
@@ -4,13 +4,16 @@ import { AdminSidebar } from "../../components/Sidebar"
 
 export default function AdminLayout() {
 	return (
-		<div className="min-h-screen admin-animated-bg">
-			<AdminSidebar />
-			<main className="lg:pl-64">
-				<div className="p-6 pt-16 lg:pt-6">
-					<Outlet />
-				</div>
-			</main>
+		<div className="min-h-screen relative overflow-hidden bg-slate-950">
+			<div className="absolute inset-0 admin-animated-bg" aria-hidden="true" />
+			<div className="relative z-10">
+				<AdminSidebar />
+				<main className="lg:pl-64">
+					<div className="p-6 pt-16 lg:pt-6">
+						<Outlet />
+					</div>
+				</main>
+			</div>
 		</div>
 	)
 }

--- a/admin/sysgd-admin/src/components/layouts/AdminLayout.tsx
+++ b/admin/sysgd-admin/src/components/layouts/AdminLayout.tsx
@@ -4,7 +4,7 @@ import { AdminSidebar } from "../../components/Sidebar"
 
 export default function AdminLayout() {
 	return (
-		<div className="min-h-screen bg-background">
+		<div className="min-h-screen admin-animated-bg">
 			<AdminSidebar />
 			<main className="lg:pl-64">
 				<div className="p-6 pt-16 lg:pt-6">

--- a/admin/sysgd-admin/src/index.css
+++ b/admin/sysgd-admin/src/index.css
@@ -164,3 +164,66 @@
     @apply bg-background text-foreground;
   }
 }
+
+.admin-animated-bg {
+  background-color: #081b3a;
+  background-image:
+    radial-gradient(circle at 20% 30%, rgba(79, 172, 254, 0.45) 0, rgba(79, 172, 254, 0) 35%),
+    radial-gradient(circle at 80% 20%, rgba(0, 210, 255, 0.35) 0, rgba(0, 210, 255, 0) 30%),
+    radial-gradient(circle at 50% 70%, rgba(43, 108, 176, 0.5) 0, rgba(43, 108, 176, 0) 40%),
+    radial-gradient(circle at 25% 80%, rgba(120, 190, 255, 0.35) 0, rgba(120, 190, 255, 0) 45%),
+    radial-gradient(circle at 75% 65%, rgba(70, 130, 255, 0.3) 0, rgba(70, 130, 255, 0) 50%),
+    radial-gradient(circle at 15% 50%, rgba(255, 255, 255, 0.12) 0, rgba(255, 255, 255, 0) 35%),
+    radial-gradient(circle at 85% 85%, rgba(255, 255, 255, 0.08) 0, rgba(255, 255, 255, 0) 40%);
+  background-size: 260% 260%;
+  animation: admin-atom-pulse 22s ease-in-out infinite;
+  position: relative;
+  overflow: hidden;
+}
+
+.admin-animated-bg::before,
+.admin-animated-bg::after {
+  content: "";
+  position: absolute;
+  inset: -25% -20%;
+  pointer-events: none;
+  background-image:
+    radial-gradient(circle, rgba(173, 216, 255, 0.55) 0 2px, transparent 3px),
+    radial-gradient(circle, rgba(137, 196, 255, 0.4) 0 1.5px, transparent 3px),
+    radial-gradient(circle, rgba(255, 255, 255, 0.35) 0 1px, transparent 2px);
+  background-size: 140px 140px, 220px 220px, 320px 320px;
+  opacity: 0.65;
+  mix-blend-mode: screen;
+}
+
+.admin-animated-bg::before {
+  animation: admin-atom-drift 30s linear infinite;
+}
+
+.admin-animated-bg::after {
+  animation: admin-atom-drift 38s linear infinite reverse;
+}
+
+@keyframes admin-atom-pulse {
+  0% {
+    background-position: 0% 0%;
+  }
+  50% {
+    background-position: 100% 60%;
+  }
+  100% {
+    background-position: 0% 0%;
+  }
+}
+
+@keyframes admin-atom-drift {
+  0% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  50% {
+    transform: translate3d(-6%, 4%, 0) scale(1.05);
+  }
+  100% {
+    transform: translate3d(6%, -5%, 0) scale(1);
+  }
+}

--- a/admin/sysgd-admin/src/index.css
+++ b/admin/sysgd-admin/src/index.css
@@ -166,42 +166,54 @@
 }
 
 .admin-animated-bg {
-  background-color: #081b3a;
+  background-color: #041226;
   background-image:
-    radial-gradient(circle at 20% 30%, rgba(79, 172, 254, 0.45) 0, rgba(79, 172, 254, 0) 35%),
-    radial-gradient(circle at 80% 20%, rgba(0, 210, 255, 0.35) 0, rgba(0, 210, 255, 0) 30%),
-    radial-gradient(circle at 50% 70%, rgba(43, 108, 176, 0.5) 0, rgba(43, 108, 176, 0) 40%),
-    radial-gradient(circle at 25% 80%, rgba(120, 190, 255, 0.35) 0, rgba(120, 190, 255, 0) 45%),
-    radial-gradient(circle at 75% 65%, rgba(70, 130, 255, 0.3) 0, rgba(70, 130, 255, 0) 50%),
-    radial-gradient(circle at 15% 50%, rgba(255, 255, 255, 0.12) 0, rgba(255, 255, 255, 0) 35%),
-    radial-gradient(circle at 85% 85%, rgba(255, 255, 255, 0.08) 0, rgba(255, 255, 255, 0) 40%);
-  background-size: 260% 260%;
-  animation: admin-atom-pulse 22s ease-in-out infinite;
-  position: relative;
+    radial-gradient(circle at 20% 30%, rgba(94, 196, 255, 0.55) 0, rgba(94, 196, 255, 0) 40%),
+    radial-gradient(circle at 80% 20%, rgba(0, 210, 255, 0.45) 0, rgba(0, 210, 255, 0) 35%),
+    radial-gradient(circle at 50% 70%, rgba(72, 135, 255, 0.55) 0, rgba(72, 135, 255, 0) 45%),
+    radial-gradient(circle at 25% 80%, rgba(140, 210, 255, 0.4) 0, rgba(140, 210, 255, 0) 50%),
+    radial-gradient(circle at 75% 65%, rgba(90, 140, 255, 0.35) 0, rgba(90, 140, 255, 0) 55%),
+    radial-gradient(circle at 15% 50%, rgba(255, 255, 255, 0.18) 0, rgba(255, 255, 255, 0) 40%),
+    radial-gradient(circle at 85% 85%, rgba(255, 255, 255, 0.12) 0, rgba(255, 255, 255, 0) 45%);
+  background-size: 240% 240%;
+  animation: admin-atom-pulse 18s ease-in-out infinite;
+  pointer-events: none;
   overflow: hidden;
 }
 
-.admin-animated-bg::before,
-.admin-animated-bg::after {
+.admin-animated-bg::before {
   content: "";
   position: absolute;
   inset: -25% -20%;
-  pointer-events: none;
   background-image:
-    radial-gradient(circle, rgba(173, 216, 255, 0.55) 0 2px, transparent 3px),
-    radial-gradient(circle, rgba(137, 196, 255, 0.4) 0 1.5px, transparent 3px),
-    radial-gradient(circle, rgba(255, 255, 255, 0.35) 0 1px, transparent 2px);
-  background-size: 140px 140px, 220px 220px, 320px 320px;
-  opacity: 0.65;
+    radial-gradient(circle, rgba(173, 216, 255, 0.7) 0 2px, transparent 3px),
+    radial-gradient(circle, rgba(137, 196, 255, 0.5) 0 1.5px, transparent 3px),
+    radial-gradient(circle, rgba(255, 255, 255, 0.45) 0 1px, transparent 2px),
+    radial-gradient(ellipse at center, rgba(120, 190, 255, 0.35) 0%, rgba(120, 190, 255, 0) 60%);
+  background-size: 140px 140px, 220px 220px, 320px 320px, 600px 600px;
+  opacity: 0.8;
   mix-blend-mode: screen;
-}
-
-.admin-animated-bg::before {
-  animation: admin-atom-drift 30s linear infinite;
+  filter: drop-shadow(0 0 12px rgba(90, 170, 255, 0.4));
+  animation: admin-atom-drift 26s linear infinite;
 }
 
 .admin-animated-bg::after {
-  animation: admin-atom-drift 38s linear infinite reverse;
+  content: "";
+  position: absolute;
+  inset: -20% -10%;
+  background-image:
+    radial-gradient(circle, rgba(180, 220, 255, 0.7) 0 2px, transparent 3px),
+    radial-gradient(circle, rgba(255, 255, 255, 0.5) 0 1px, transparent 2px),
+    repeating-conic-gradient(
+      from 0deg,
+      rgba(120, 190, 255, 0.25) 0deg 12deg,
+      rgba(120, 190, 255, 0) 12deg 24deg
+    );
+  background-size: 200px 200px, 320px 320px, 500px 500px;
+  opacity: 0.7;
+  mix-blend-mode: screen;
+  filter: drop-shadow(0 0 16px rgba(100, 170, 255, 0.45));
+  animation: admin-atom-drift 34s linear infinite reverse;
 }
 
 @keyframes admin-atom-pulse {


### PR DESCRIPTION
### Motivation

- Dar al panel de administración un fondo azul animado con “átomos” interlineándose para hacerlo más atractivo y distintivo.
- Aplicar el efecto de manera global al layout para cubrir toda el área administrativa sin modificar cada página individualmente.

### Description

- Reemplacé la clase de fondo en `AdminLayout.tsx` para usar `admin-animated-bg` en lugar de `bg-background` para que el layout admin use el nuevo estilo. 
- Añadí reglas CSS en `src/index.css` que crean múltiples gradientes radiales, pseudo-elementos con partículas y `mix-blend-mode: screen` para capas superpuestas. 
- Implementé las animaciones `@keyframes admin-atom-pulse` y `@keyframes admin-atom-drift` para desplazar y pulsar los gradientes y las partículas de forma fluida. 

### Testing

- Inicié el servidor de desarrollo con `npm run dev` para comprobar que la aplicación arranca correctamente y esto se completó con éxito. 
- Ejecuté un script de Playwright que navegó a `http://127.0.0.1:4173/admin` y tomó una captura de pantalla del fondo animado, y la ejecución finalizó correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989f1429e248322b4003751f238d2f4)