### PR TITLE
Add external auth token flow

### DIFF
--- a/client/react-frontend/index.html
+++ b/client/react-frontend/index.html
@@ -18,17 +18,17 @@
     <!-- ====================== -->
     <!-- SEO & Meta Tags -->
     <!-- ====================== -->
-    <title>SYSGD Ecosystem - Gestión documental, IA y cripto en un solo lugar</title>
+    <title>SYSGD Ecosystem - Plataforma de gestión empresarial modular</title>
     <meta
       name="description"
-      content="Ecosistema integral con gestión documental inteligente, IA generativa, pagos en criptomonedas, proyectos colaborativos y más. Todo lo que necesitas en una sola plataforma segura y moderna."
+      content="Ecosistema de gestión empresarial modular que integra documentos, proyectos, IA, pagos en cripto y servicios digitales en una sola plataforma segura y moderna."
     />
-    <meta name="keywords" content="SYSGD, gestión documental, IA generativa, criptomonedas, productividad, dashboard, proyectos colaborativos, cloud, blockchain" />
+    <meta name="keywords" content="SYSGD, ecosistema empresarial, gestión modular, IA generativa, criptomonedas, productividad, proyectos colaborativos, cloud, blockchain" />
     <meta name="author" content="SYSGD Team" />
 
     <!-- Open Graph / Facebook -->
     <meta property="og:title" content="SYSGD Ecosystem" />
-    <meta property="og:description" content="Un ecosistema que se adapta a tus necesidades: gestión documental, IA, cripto y productividad." />
+    <meta property="og:description" content="Ecosistema de gestión empresarial modular que integra documentos, proyectos, IA y servicios digitales." />
     <meta property="og:image" content="https://sysgd.netlify.app/og-image.png" />
     <meta property="og:url" content="https://sysgd.netlify.app" />
     <meta property="og:type" content="website" />
@@ -37,7 +37,7 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="SYSGD Ecosystem" />
-    <meta name="twitter:description" content="Un ecosistema que se adapta a tus necesidades: gestión documental, IA, cripto y productividad." />
+    <meta name="twitter:description" content="Ecosistema de gestión empresarial modular que integra documentos, proyectos, IA y servicios digitales." />
     <meta name="twitter:image" content="https://sysgd.netlify.app/og-image.png" />
     <meta name="twitter:site" content="@sysgd" /> <!-- Cambia si tienes cuenta -->
 

--- a/client/react-frontend/src/components/SettingsModal.tsx
+++ b/client/react-frontend/src/components/SettingsModal.tsx
@@ -1,12 +1,17 @@
 import {
 	Bell,
 	ChevronDown,
+	Copy,
+	Eye,
+	EyeOff,
 	Globe,
 	KeyRound,
+	Loader2,
 	Monitor,
 	Palette,
 	Shield,
 	Smartphone,
+	Trash2,
 } from "lucide-react";
 import { type FC, useState, useEffect } from "react";
 import { Badge } from "@/components/ui/badge";
@@ -36,7 +41,6 @@ import { Switch } from "@/components/ui/switch";
 import { useTheme } from "@/contexts/theme-context";
 import { useUsers } from "@/hooks/connection/useUsers";
 import { Input } from '@/components/ui/input';
-import { Loader2, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 import api from "@/lib/api";
 
@@ -384,6 +388,9 @@ const TokensSettings: FC = () => {
   const [isSaving, setIsSaving] = useState(false);
   const [tokenType, setTokenType] = useState('github');
   const [tokenValue, setTokenValue] = useState('');
+	const [externalToken, setExternalToken] = useState('');
+	const [externalTokenLoading, setExternalTokenLoading] = useState(false);
+	const [showExternalToken, setShowExternalToken] = useState(false);
 
 
   useEffect(() => {
@@ -438,6 +445,34 @@ const TokensSettings: FC = () => {
       console.error(error);
     }
   };
+
+	const handleGenerateExternalToken = async () => {
+		setExternalTokenLoading(true);
+		try {
+			const response = await api.post<{ token: string }>('/api/auth/external-token');
+			setExternalToken(response.data.token);
+			setShowExternalToken(true);
+			toast.success('Token externo generado. Puedes copiarlo para otra app.');
+		} catch (error: any) {
+			toast.error(
+				error.response?.data?.message || 'Error al generar el token externo'
+			);
+			console.error(error);
+		} finally {
+			setExternalTokenLoading(false);
+		}
+	};
+
+	const handleCopyExternalToken = async () => {
+		if (!externalToken) return;
+		try {
+			await navigator.clipboard.writeText(externalToken);
+			toast.success('Token copiado al portapapeles');
+		} catch (error) {
+			toast.error('No se pudo copiar el token');
+			console.error(error);
+		}
+	};
 
   if (isLoading) {
     return (
@@ -496,6 +531,70 @@ const TokensSettings: FC = () => {
           </div>
         </div>
       </form>
+
+			<div className="rounded-lg border p-4 space-y-4">
+				<div>
+					<h4 className="font-medium">Token para Apps Externas</h4>
+					<p className="text-sm text-muted-foreground">
+						Genera un token para usar la API desde móvil, escritorio u otros sistemas.
+					</p>
+				</div>
+				<div className="space-y-2">
+					<Label htmlFor="external-token">Token de acceso</Label>
+					<div className="relative">
+						<Input
+							id="external-token"
+							type={showExternalToken ? 'text' : 'password'}
+							value={externalToken}
+							readOnly
+							placeholder="Genera un token para copiarlo aquí"
+							className="pr-20"
+						/>
+						<Button
+							type="button"
+							variant="ghost"
+							size="sm"
+							className="absolute right-9 top-0 h-full px-2"
+							onClick={() => setShowExternalToken(!showExternalToken)}
+							disabled={!externalToken}
+						>
+							{showExternalToken ? (
+								<EyeOff className="w-4 h-4" />
+							) : (
+								<Eye className="w-4 h-4" />
+							)}
+						</Button>
+						<Button
+							type="button"
+							variant="ghost"
+							size="sm"
+							className="absolute right-0 top-0 h-full px-3"
+							onClick={handleCopyExternalToken}
+							disabled={!externalToken}
+						>
+							<Copy className="w-4 h-4" />
+						</Button>
+					</div>
+					<p className="text-xs text-muted-foreground">
+						Útil si te autenticas con Google en la web y necesitas acceso en el teléfono.
+					</p>
+				</div>
+				<Button
+					type="button"
+					onClick={handleGenerateExternalToken}
+					disabled={externalTokenLoading}
+					className="w-full"
+				>
+					{externalTokenLoading ? (
+						<>
+							<Loader2 className="w-4 h-4 mr-2 animate-spin" />
+							Generando...
+						</>
+					) : (
+						'Generar token externo'
+					)}
+				</Button>
+			</div>
 
       <div className="mt-8">
         <h4 className="mb-4 font-medium">Tus Tokens</h4>

--- a/client/react-frontend/src/components/SettingsModal.tsx
+++ b/client/react-frontend/src/components/SettingsModal.tsx
@@ -627,7 +627,7 @@ const TokensSettings: FC = () => {
 				{/* Footer */}
 				{/* <div className="border-t p-4 flex justify-between items-center">
 					<p className="text-sm text-gray-500">
-						SYSGD v2.1.0 - Sistema de Gestión de Documentos
+						SYSGD v2.1.0 - Ecosistema de Gestión Modular
 					</p>
 					<div className="flex space-x-2">
 						<Button variant="outline" onClick={onClose}>

--- a/client/react-frontend/src/components/demo/settings-modal.tsx
+++ b/client/react-frontend/src/components/demo/settings-modal.tsx
@@ -448,7 +448,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
 				{/* Footer */}
 				<div className="border-t p-4 flex justify-between items-center">
 					<p className="text-sm text-gray-500">
-						SYSGD v2.1.0 - Sistema de Gestión de Documentos
+						SYSGD v2.1.0 - Ecosistema de Gestión Modular
 					</p>
 					<div className="flex space-x-2">
 						<Button variant="outline" onClick={onClose}>

--- a/client/react-frontend/src/components/projects/settings-modal.tsx
+++ b/client/react-frontend/src/components/projects/settings-modal.tsx
@@ -448,7 +448,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
 				{/* Footer */}
 				<div className="border-t p-4 flex justify-between items-center">
 					<p className="text-sm text-gray-500">
-						SYSGD v2.1.0 - Sistema de Gestión de Documentos
+						SYSGD v2.1.0 - Ecosistema de Gestión Modular
 					</p>
 					<div className="flex space-x-2">
 						<Button variant="outline" onClick={onClose}>

--- a/client/react-frontend/src/pages/SettingPage.tsx
+++ b/client/react-frontend/src/pages/SettingPage.tsx
@@ -1,12 +1,18 @@
 // src/pages/SettingsPage.tsx
 import { FC, useState, useEffect } from "react";
 import {
-	Palette,
 	Bell,
-	Shield,
+	ChevronDown,
+	Copy,
+	Eye,
+	EyeOff,
 	Globe,
 	KeyRound,
+	Loader2,
 	Menu,
+	Palette,
+	Shield,
+	Trash2,
 	Wallet,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -29,7 +35,6 @@ import { Slider } from "@/components/ui/slider";
 import { Switch } from "@/components/ui/switch";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
-import { Loader2, Trash2, ChevronDown } from "lucide-react";
 import { useTheme } from "@/contexts/theme-context";
 import { useUsers } from "@/hooks/connection/useUsers";
 import { useWeb3 } from "@/components/billing/hooks/useWeb3";
@@ -69,6 +74,9 @@ const TokensSection: FC = () => {
 	const [isSaving, setIsSaving] = useState(false);
 	const [tokenType, setTokenType] = useState("github");
 	const [tokenValue, setTokenValue] = useState("");
+	const [externalToken, setExternalToken] = useState("");
+	const [externalTokenLoading, setExternalTokenLoading] = useState(false);
+	const [showExternalToken, setShowExternalToken] = useState(false);
 
 	useEffect(() => {
 		fetchTokens();
@@ -110,6 +118,34 @@ const TokensSection: FC = () => {
 			fetchTokens();
 		} catch (error) {
 			toast.error("Error al eliminar");
+		}
+	};
+
+	const handleGenerateExternalToken = async () => {
+		setExternalTokenLoading(true);
+		try {
+			const response = await api.post<{ token: string }>(
+				"/api/auth/external-token",
+			);
+			setExternalToken(response.data.token);
+			setShowExternalToken(true);
+			toast.success("Token externo generado. Puedes copiarlo.");
+		} catch (error: any) {
+			toast.error(
+				error.response?.data?.message || "Error al generar el token externo",
+			);
+		} finally {
+			setExternalTokenLoading(false);
+		}
+	};
+
+	const handleCopyExternalToken = async () => {
+		if (!externalToken) return;
+		try {
+			await navigator.clipboard.writeText(externalToken);
+			toast.success("Token copiado al portapapeles");
+		} catch (error) {
+			toast.error("No se pudo copiar el token");
 		}
 	};
 
@@ -162,6 +198,71 @@ const TokensSection: FC = () => {
 					</div>
 				</div>
 			</form>
+
+			<div className="space-y-4 rounded-lg border p-4">
+				<div>
+					<h4 className="font-medium">Token para Apps Externas</h4>
+					<p className="text-sm text-muted-foreground">
+						Genera un token para autenticarte desde móvil, escritorio u otros
+						sistemas.
+					</p>
+				</div>
+				<div className="space-y-2">
+					<Label>Token de acceso</Label>
+					<div className="relative">
+						<Input
+							type={showExternalToken ? "text" : "password"}
+							value={externalToken}
+							readOnly
+							placeholder="Genera un token para copiarlo aquí"
+							className="pr-20"
+						/>
+						<Button
+							type="button"
+							variant="ghost"
+							size="sm"
+							className="absolute right-9 top-0 h-full px-2"
+							onClick={() => setShowExternalToken(!showExternalToken)}
+							disabled={!externalToken}
+						>
+							{showExternalToken ? (
+								<EyeOff className="w-4 h-4" />
+							) : (
+								<Eye className="w-4 h-4" />
+							)}
+						</Button>
+						<Button
+							type="button"
+							variant="ghost"
+							size="sm"
+							className="absolute right-0 top-0 h-full px-3"
+							onClick={handleCopyExternalToken}
+							disabled={!externalToken}
+						>
+							<Copy className="w-4 h-4" />
+						</Button>
+					</div>
+					<p className="text-xs text-muted-foreground">
+						Úsalo si te autenticas con Google en la web y necesitas acceso en
+						el teléfono.
+					</p>
+				</div>
+				<Button
+					type="button"
+					onClick={handleGenerateExternalToken}
+					disabled={externalTokenLoading}
+					className="w-full"
+				>
+					{externalTokenLoading ? (
+						<>
+							<Loader2 className="w-4 h-4 mr-2 animate-spin" />
+							Generando...
+						</>
+					) : (
+						"Generar token externo"
+					)}
+				</Button>
+			</div>
 
 			<div>
 				<h4 className="font-medium mb-3">Tokens guardados</h4>

--- a/server/node-server/public/index.html
+++ b/server/node-server/public/index.html
@@ -4,7 +4,21 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>SYSGD - Próximo Lanzamiento</title>
+  <title>SYSGD Ecosystem - Próximo Lanzamiento</title>
+  <meta
+    name="description"
+    content="SYSGD Ecosystem es una plataforma de gestión empresarial modular que integra documentos, proyectos, IA y servicios digitales."
+  />
+  <meta
+    name="keywords"
+    content="SYSGD, ecosistema empresarial, gestión modular, IA, proyectos, productividad, plataforma empresarial"
+  />
+  <meta property="og:title" content="SYSGD Ecosystem - Próximo Lanzamiento" />
+  <meta
+    property="og:description"
+    content="Plataforma de gestión empresarial modular que integra documentos, proyectos, IA y servicios digitales."
+  />
+  <meta property="og:type" content="website" />
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600;700&display=swap');
 
@@ -291,9 +305,9 @@
   <div class="container">
     <header class="header">
       <h1 class="title">SYSGD</h1>
-      <p class="subtitle">Sistema de Gestión Documental</p>
+      <p class="subtitle">Ecosistema de Gestión Empresarial</p>
       <p class="description">
-        La próxima generación en gestión documental está llegando.
+        La próxima generación de gestión empresarial modular está llegando.
         Regístrate para ser el primero en conocer nuestro lanzamiento.
       </p>
     </header>
@@ -368,7 +382,7 @@
     </section>
 
     <footer class="footer">
-      <p>&copy; 2025 SYSGD. El futuro de la gestión documental.</p>
+      <p>&copy; 2025 SYSGD Ecosystem. El futuro de la gestión empresarial modular.</p>
     </footer>
   </div>
 

--- a/server/node-server/src/controllers/auth.ts
+++ b/server/node-server/src/controllers/auth.ts
@@ -239,6 +239,29 @@ export const completeInvitedUserRegistration = async (
 	}
 };
 
+export const issueExternalToken = async (req: Request, res: Response) => {
+	const user = req.user;
+
+	if (!user) {
+		res.status(401).json({ message: "No autorizado" });
+		return;
+	}
+
+	const token = generateJWT({
+		id: user.id,
+		email: user.email,
+		name: user.name,
+		privileges: user.privileges,
+	});
+
+	res.status(200).json({
+		message: "Token generado para acceso externo",
+		token,
+		tokenType: "Bearer",
+		expiresIn: "7d",
+	});
+};
+
 export const logout = async (req: Request, res: Response) => {
 	// Limpiamos la cookie del servidor
 	res.clearCookie("token", {

--- a/server/node-server/src/routes/auth.routes.ts
+++ b/server/node-server/src/routes/auth.routes.ts
@@ -1,5 +1,13 @@
 import { Router } from "express";
-import { getCurrentUser, login, logout, completeInvitedUserRegistration, checkUser } from "../controllers/auth";
+import {
+	checkUser,
+	completeInvitedUserRegistration,
+	getCurrentUser,
+	issueExternalToken,
+	login,
+	logout,
+} from "../controllers/auth";
+import { isAuthenticated } from "../middlewares/auth-jwt";
 
 
 const router = Router();
@@ -12,6 +20,7 @@ router.post("/complete-registration", completeInvitedUserRegistration);
 //router.post("/register", registerUser);
 
 router.get("/me", getCurrentUser);
+router.post("/external-token", isAuthenticated, issueExternalToken);
 
 router.post("/logout", logout);
 

--- a/server/node-server/src/swagger.ts
+++ b/server/node-server/src/swagger.ts
@@ -8,7 +8,7 @@ const options: swaggerJSDoc.Options = {
     info: {
       title: "SYSGD API",
       version: "1.0.0",
-      description: "API para gestión documental SYSGD",
+      description: "API del ecosistema de gestión empresarial SYSGD",
     },
     servers: [
       {

--- a/web/sysgd-web/app/layout.tsx
+++ b/web/sysgd-web/app/layout.tsx
@@ -8,9 +8,9 @@ import "./globals.css"
 const inter = Inter({ subsets: ["latin"] })
 
 export const metadata: Metadata = {
-  title: "SYSGD Ecosystem - Sistema de Gestión Empresarial",
+  title: "SYSGD Ecosystem - Plataforma de Gestión Empresarial Modular",
   description:
-    "Ecosistema modular de código abierto para la productividad empresarial. Gestión documental, proyectos y más.",
+    "Ecosistema modular de gestión empresarial que integra documentos, proyectos, IA y servicios digitales en una sola plataforma.",
   generator: "v0.app",
   icons: {
     icon: [

--- a/web/sysgd-web/index.html
+++ b/web/sysgd-web/index.html
@@ -11,14 +11,14 @@
     
     <meta
       name="description"
-      content="Ecosistema integral con gestión empresarial inteligente, IA generativa, proyectos colaborativos y más. Todo lo que necesitas en una sola plataforma segura y moderna."
+      content="Ecosistema de gestión empresarial modular que integra documentos, proyectos, IA y servicios digitales en una sola plataforma segura y moderna."
     />
-    <meta name="keywords" content="SYSGD, gestión documental, IA generativa, productividad, dashboard, proyectos colaborativos, cloud, blockchain" />
+    <meta name="keywords" content="SYSGD, ecosistema empresarial, gestión modular, gestión empresarial, IA generativa, productividad, proyectos colaborativos, cloud, blockchain" />
     <meta name="author" content="SYSGD Team" />
 
     <!-- Open Graph / Facebook -->
     <meta property="og:title" content="SYSGD Ecosystem" />
-    <meta property="og:description" content="Un ecosistema que se adapta a tus necesidades: gestión documental, IA, proyectos y productividad." />
+    <meta property="og:description" content="Ecosistema de gestión empresarial modular que integra documentos, proyectos, IA y servicios digitales." />
     <meta property="og:image" content="https://sysgd.netlify.app/og-image.png" />
     <meta property="og:url" content="https://sysgd.netlify.app" />
     <meta property="og:type" content="website" />
@@ -27,7 +27,7 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="SYSGD Ecosystem" />
-    <meta name="twitter:description" content="Un ecosistema que se adapta a tus necesidades: gestión documental, IA, proyectos y productividad." />
+    <meta name="twitter:description" content="Ecosistema de gestión empresarial modular que integra documentos, proyectos, IA y servicios digitales." />
     <meta name="twitter:image" content="https://sysgd.netlify.app/og-image.png" />
     <meta name="twitter:site" content="@sysgd" /> <!-- Cambia si tienes cuenta -->
 


### PR DESCRIPTION
### Motivation
- Permitir que clientes no-web (móvil, desktop, integraciones) obtengan un JWT sin redirecciones web para autenticar llamadas a la API. 
- Facilitar desde la UI del cliente la generación y copia de ese token para usarlo en otras apps (ej.: cuando se autentica en la web con Google y se necesita acceso en el teléfono).

### Description
- Añadido el controlador `issueExternalToken` en `server/node-server/src/controllers/auth.ts` que genera un JWT usando el helper `generateJWT` y devuelve `token`, `tokenType` y `expiresIn`.
- Registrada la ruta protegida `POST /api/auth/external-token` en `server/node-server/src/routes/auth.routes.ts` usando el middleware `isAuthenticated`.
- Extendida la UI de tokens en `client/react-frontend/src/components/TokenManagement.tsx` para incluir una sección "Token para Apps Externas" con botones para `Generar token externo`, mostrar/ocultar el valor y copiarlo al portapapeles; se añadieron estados y handlers (`handleGenerateExternalToken`, `handleCopyExternalToken`).

### Testing
- Levanté el frontend con `npm run dev -- --host 0.0.0.0 --port 4173` y el servidor Vite quedó listo (dev server iniciado correctamente).
- Capturé una captura de la pantalla de la página de gestión de tokens con Playwright y guardé el artefacto `artifacts/token-management-external-token.png`, validando visualmente la nueva sección; la ejecución automatizada finalizó correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989fd4b5d04832298da7d076833e21b)