### PR TITLE
feat(tasks): cambio rápido de estado de tareas desde la tabla

### DIFF
--- a/client/react-frontend/src/components/projects/task-management/TaskConfigManager.tsx
+++ b/client/react-frontend/src/components/projects/task-management/TaskConfigManager.tsx
@@ -11,18 +11,41 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import {
 	Collapsible,
 	CollapsibleContent,
 	CollapsibleTrigger,
 } from "@/components/ui/collapsible";
-import { useTaskConfig } from "./hooks/useTaskConfig";
+import { getStatusIcon } from "@/utils/util-components";
+import {
+	type TaskStateIconName,
+	useTaskConfig,
+} from "./hooks/useTaskConfig";
 
 const TaskConfigManager: FC<{ projectId: string }> = ({ projectId }) => {
 	const { config, loading, updateConfig } = useTaskConfig(projectId);
 	const [newType, setNewType] = useState("");
 	const [newPriority, setNewPriority] = useState("");
 	const [newState, setNewState] = useState("");
+	const [newStateIcon, setNewStateIcon] =
+		useState<TaskStateIconName>("circle");
 	const [openSections, setOpenSections] = useState<Record<string, boolean>>({});
+
+	const stateIconOptions: TaskStateIconName[] = [
+		"circle",
+		"clock",
+		"check-circle",
+		"pause-circle",
+		"x-circle",
+		"alert-circle",
+		"play-circle",
+	];
 
 	const toggleSection = (section: string) => {
 		setOpenSections((prev) => ({
@@ -84,11 +107,13 @@ const TaskConfigManager: FC<{ projectId: string }> = ({ projectId }) => {
 			{
 				name: newState.trim(),
 				color: randomColor,
+				icon: newStateIcon,
 				requires_context: false,
 			},
 		];
 		updateConfig({ ...config!, states: updatedStates });
 		setNewState("");
+		setNewStateIcon("circle");
 	};
 
 	const handleDeleteType = (typeName: string) => {
@@ -332,10 +357,13 @@ const TaskConfigManager: FC<{ projectId: string }> = ({ projectId }) => {
 										className="flex items-center gap-2 p-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 hover:border-gray-300 dark:hover:border-gray-600 transition-colors"
 									>
 										<GripVertical className="h-4 w-4 text-gray-400 cursor-move" />
-										<div
-											className="w-3 h-3 rounded-full flex-shrink-0"
-											style={{ backgroundColor: state.color }}
-										/>
+										<div className="flex-shrink-0">
+											{getStatusIcon(state.name, {
+												states: [state],
+												types: [],
+												priorities: [],
+											})}
+										</div>
 										<span className="flex-1 text-sm">{state.name}</span>
 										{state.requires_context && (
 											<Badge variant="secondary" className="text-xs">
@@ -355,7 +383,7 @@ const TaskConfigManager: FC<{ projectId: string }> = ({ projectId }) => {
 							</div>
 
 							{/* Input para agregar nuevo */}
-							<div className="flex gap-2 pt-2 border-t border-gray-200 dark:border-gray-700">
+							<div className="grid grid-cols-1 sm:grid-cols-[1fr_220px_auto] gap-2 pt-2 border-t border-gray-200 dark:border-gray-700">
 								<Input
 									placeholder="Nuevo estado (ej: En revisión...)"
 									value={newState}
@@ -363,6 +391,49 @@ const TaskConfigManager: FC<{ projectId: string }> = ({ projectId }) => {
 									onKeyPress={(e) => e.key === "Enter" && handleAddState()}
 									className="text-sm"
 								/>
+								<Select
+									value={newStateIcon}
+									onValueChange={(value) => setNewStateIcon(value as TaskStateIconName)}
+								>
+									<SelectTrigger className="text-sm">
+										<div className="flex items-center gap-2">
+											{getStatusIcon("", {
+												states: [
+													{
+														name: "preview",
+														color: "#6b7280",
+														icon: newStateIcon,
+														requires_context: false,
+													},
+												],
+												types: [],
+												priorities: [],
+											})}
+											<SelectValue placeholder="Icono" />
+										</div>
+									</SelectTrigger>
+									<SelectContent>
+										{stateIconOptions.map((icon) => (
+											<SelectItem key={icon} value={icon}>
+												<div className="flex items-center gap-2">
+													{getStatusIcon("", {
+														states: [
+															{
+																name: "preview",
+																color: "#6b7280",
+																icon,
+																requires_context: false,
+															},
+														],
+														types: [],
+														priorities: [],
+													})}
+													<span>{icon}</span>
+												</div>
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
 								<Button
 									onClick={handleAddState}
 									size="sm"

--- a/client/react-frontend/src/components/projects/task-management/TaskManagement.tsx
+++ b/client/react-frontend/src/components/projects/task-management/TaskManagement.tsx
@@ -200,8 +200,8 @@ const TaskManagement: FC<{ project_id: string }> = ({ project_id }) => {
 		return [...new Set(tasks.map((task) => task.status))];
 	};
 
-	const statusOptions =
-		config?.states?.map((state) => state.name) ?? getUniqueStatuses();
+	// const statusOptions =
+	// 	config?.states?.map((state) => state.name) ?? getUniqueStatuses();
 
 	return (
 		<div className="bg-white h-full flex flex-col rounded-lg dark:border shadow-sm dark:bg-gray-800 dark:border-gray-700">

--- a/client/react-frontend/src/components/projects/task-management/TaskManagement.tsx
+++ b/client/react-frontend/src/components/projects/task-management/TaskManagement.tsx
@@ -476,14 +476,17 @@ const TaskManagement: FC<{ project_id: string }> = ({ project_id }) => {
 									>
 										<SelectTrigger className="h-8 w-40">
 											<div className="flex items-center gap-2 truncate">
-												{getStatusIcon(task.status)}
+												{getStatusIcon(task.status, config)}
 												<SelectValue />
 											</div>
 										</SelectTrigger>
 										<SelectContent>
 											{statusOptions.map((status) => (
 												<SelectItem key={status} value={status}>
-													{status}
+													<div className="flex items-center gap-2">
+														{getStatusIcon(status, config)}
+														<span>{status}</span>
+													</div>
 												</SelectItem>
 											))}
 										</SelectContent>
@@ -567,12 +570,15 @@ const TaskManagement: FC<{ project_id: string }> = ({ project_id }) => {
 										}
 									>
 										<SelectTrigger className="h-8 w-10 p-0 justify-center">
-											{getStatusIcon(task.status)}
+											{getStatusIcon(task.status, config)}
 										</SelectTrigger>
 										<SelectContent>
 											{statusOptions.map((status) => (
 												<SelectItem key={status} value={status}>
-													{status}
+													<div className="flex items-center gap-2">
+														{getStatusIcon(status, config)}
+														<span>{status}</span>
+													</div>
 												</SelectItem>
 											))}
 										</SelectContent>

--- a/client/react-frontend/src/components/projects/task-management/TaskManagement.tsx
+++ b/client/react-frontend/src/components/projects/task-management/TaskManagement.tsx
@@ -477,7 +477,7 @@ const TaskManagement: FC<{ project_id: string }> = ({ project_id }) => {
 										<SelectTrigger className="h-8 w-40">
 											<div className="flex items-center gap-2 truncate">
 												{getStatusIcon(task.status, config)}
-												<SelectValue />
+												<span className="truncate">{task.status}</span>
 											</div>
 										</SelectTrigger>
 										<SelectContent>

--- a/client/react-frontend/src/components/projects/task-management/TaskManagement.tsx
+++ b/client/react-frontend/src/components/projects/task-management/TaskManagement.tsx
@@ -112,6 +112,14 @@ const TaskManagement: FC<{ project_id: string }> = ({ project_id }) => {
 		setisDialogOpenDialog(false);
 	};
 
+	const handleQuickStatusChange = async (taskId: string, status: string) => {
+		await updateTask(taskId, { status });
+
+		if (selectedTask?.id === taskId) {
+			setselectedTask((prev) => (prev ? { ...prev, status } : prev));
+		}
+	};
+
 	const handleAddNewTask = () => {
 		const defaultType = config?.types?.[0]?.name ?? "Tarea";
 		const defaultPriority =
@@ -191,6 +199,9 @@ const TaskManagement: FC<{ project_id: string }> = ({ project_id }) => {
 	const getUniqueStatuses = () => {
 		return [...new Set(tasks.map((task) => task.status))];
 	};
+
+	const statusOptions = config?.states?.map((state) => state.name) ??
+		getUniqueStatuses();
 
 	return (
 		<div className="bg-white h-full flex flex-col rounded-lg dark:border shadow-sm dark:bg-gray-800 dark:border-gray-700">
@@ -451,12 +462,34 @@ const TaskManagement: FC<{ project_id: string }> = ({ project_id }) => {
 										setisDialogOpenDialog(true);
 									}}
 								>
-									{/* Desktop Version */}
-									<TableCell className="hidden md:table-cell">
-										<div className="flex items-center justify-center">
-											{getStatusIcon(task.status)}
-										</div>
-									</TableCell>
+							{/* Desktop Version */}
+							<TableCell className="hidden md:table-cell">
+								<div
+									className="flex items-center justify-center"
+									onClick={(event) => event.stopPropagation()}
+								>
+									<Select
+										value={task.status}
+										onValueChange={(value) =>
+											handleQuickStatusChange(task.id as string, value)
+										}
+									>
+										<SelectTrigger className="h-8 w-40">
+											<div className="flex items-center gap-2 truncate">
+												{getStatusIcon(task.status)}
+												<SelectValue />
+											</div>
+										</SelectTrigger>
+										<SelectContent>
+											{statusOptions.map((status) => (
+												<SelectItem key={status} value={status}>
+													{status}
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+								</div>
+							</TableCell>
 									<TableCell className="hidden md:table-cell font-medium">
 										{task.title}
 									</TableCell>
@@ -521,12 +554,31 @@ const TaskManagement: FC<{ project_id: string }> = ({ project_id }) => {
 										</div>
 									</TableCell>
 
-									{/* Mobile Version */}
-									<TableCell className="md:hidden p-2">
-										<div className="flex items-center justify-center">
+							{/* Mobile Version */}
+							<TableCell className="md:hidden p-2">
+								<div
+									className="flex items-center justify-center"
+									onClick={(event) => event.stopPropagation()}
+								>
+									<Select
+										value={task.status}
+										onValueChange={(value) =>
+											handleQuickStatusChange(task.id as string, value)
+										}
+									>
+										<SelectTrigger className="h-8 w-10 p-0 justify-center">
 											{getStatusIcon(task.status)}
-										</div>
-									</TableCell>
+										</SelectTrigger>
+										<SelectContent>
+											{statusOptions.map((status) => (
+												<SelectItem key={status} value={status}>
+													{status}
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+								</div>
+							</TableCell>
 									<TableCell className="md:hidden p-2">
 										<div className="flex flex-col gap-1">
 											<span className="font-medium text-sm line-clamp-2">

--- a/client/react-frontend/src/components/projects/task-management/TaskManagement.tsx
+++ b/client/react-frontend/src/components/projects/task-management/TaskManagement.tsx
@@ -112,13 +112,13 @@ const TaskManagement: FC<{ project_id: string }> = ({ project_id }) => {
 		setisDialogOpenDialog(false);
 	};
 
-	const handleQuickStatusChange = async (taskId: string, status: string) => {
-		await updateTask(taskId, { status });
+	// const handleQuickStatusChange = async (taskId: string, status: string) => {
+	// 	await updateTask(taskId, { status });
 
-		if (selectedTask?.id === taskId) {
-			setselectedTask((prev) => (prev ? { ...prev, status } : prev));
-		}
-	};
+	// 	if (selectedTask?.id === taskId) {
+	// 		setselectedTask((prev) => (prev ? { ...prev, status } : prev));
+	// 	}
+	// };
 
 	const handleAddNewTask = () => {
 		const defaultType = config?.types?.[0]?.name ?? "Tarea";
@@ -200,8 +200,8 @@ const TaskManagement: FC<{ project_id: string }> = ({ project_id }) => {
 		return [...new Set(tasks.map((task) => task.status))];
 	};
 
-	const statusOptions = config?.states?.map((state) => state.name) ??
-		getUniqueStatuses();
+	const statusOptions =
+		config?.states?.map((state) => state.name) ?? getUniqueStatuses();
 
 	return (
 		<div className="bg-white h-full flex flex-col rounded-lg dark:border shadow-sm dark:bg-gray-800 dark:border-gray-700">
@@ -462,37 +462,29 @@ const TaskManagement: FC<{ project_id: string }> = ({ project_id }) => {
 										setisDialogOpenDialog(true);
 									}}
 								>
-							{/* Desktop Version */}
-							<TableCell className="hidden md:table-cell">
-								<div
-									className="flex items-center justify-center"
-									onClick={(event) => event.stopPropagation()}
-								>
-									<Select
-										value={task.status}
-										onValueChange={(value) =>
-											handleQuickStatusChange(task.id as string, value)
-										}
-									>
-										<SelectTrigger className="h-8 w-40">
-											<div className="flex items-center gap-2 truncate">
+									{/* Desktop Version */}
+									<TableCell className="hidden md:table-cell">
+										<div className="flex items-center justify-center">
+											<Badge
+												className="flex items-center gap-1"
+												variant="outline"
+												style={{
+													backgroundColor:
+														config?.states?.find((s) => s.name === task.status)
+															?.color + "20",
+													borderColor: config?.states?.find(
+														(s) => s.name === task.status,
+													)?.color,
+													color: config?.states?.find(
+														(s) => s.name === task.status,
+													)?.color,
+												}}
+											>
 												{getStatusIcon(task.status, config)}
-												<span className="truncate">{task.status}</span>
-											</div>
-										</SelectTrigger>
-										<SelectContent>
-											{statusOptions.map((status) => (
-												<SelectItem key={status} value={status}>
-													<div className="flex items-center gap-2">
-														{getStatusIcon(status, config)}
-														<span>{status}</span>
-													</div>
-												</SelectItem>
-											))}
-										</SelectContent>
-									</Select>
-								</div>
-							</TableCell>
+												<span>{task.status}</span>
+											</Badge>
+										</div>
+									</TableCell>
 									<TableCell className="hidden md:table-cell font-medium">
 										{task.title}
 									</TableCell>
@@ -557,34 +549,14 @@ const TaskManagement: FC<{ project_id: string }> = ({ project_id }) => {
 										</div>
 									</TableCell>
 
-							{/* Mobile Version */}
-							<TableCell className="md:hidden p-2">
-								<div
-									className="flex items-center justify-center"
-									onClick={(event) => event.stopPropagation()}
-								>
-									<Select
-										value={task.status}
-										onValueChange={(value) =>
-											handleQuickStatusChange(task.id as string, value)
-										}
-									>
-										<SelectTrigger className="h-8 w-10 p-0 justify-center">
-											{getStatusIcon(task.status, config)}
-										</SelectTrigger>
-										<SelectContent>
-											{statusOptions.map((status) => (
-												<SelectItem key={status} value={status}>
-													<div className="flex items-center gap-2">
-														{getStatusIcon(status, config)}
-														<span>{status}</span>
-													</div>
-												</SelectItem>
-											))}
-										</SelectContent>
-									</Select>
-								</div>
-							</TableCell>
+									{/* Mobile Version */}
+									<TableCell className="md:hidden p-2">
+										<div className="flex items-center justify-center">
+											<div className="flex items-center gap-2">
+												{getStatusIcon(task.status, config)}
+											</div>
+										</div>
+									</TableCell>
 									<TableCell className="md:hidden p-2">
 										<div className="flex flex-col gap-1">
 											<span className="font-medium text-sm line-clamp-2">

--- a/client/react-frontend/src/components/projects/task-management/hooks/useTaskConfig.ts
+++ b/client/react-frontend/src/components/projects/task-management/hooks/useTaskConfig.ts
@@ -3,6 +3,15 @@ import { useCallback, useEffect, useState } from "react";
 import api from "@/lib/api";
 
 // --- Interfaces se mantienen igual ---
+export type TaskStateIconName =
+	| "circle"
+	| "clock"
+	| "check-circle"
+	| "pause-circle"
+	| "x-circle"
+	| "alert-circle"
+	| "play-circle";
+
 export interface TaskType {
 	name: string;
 	color: string;
@@ -15,6 +24,7 @@ export interface TaskPriority {
 export interface TaskState {
 	name: string;
 	color: string;
+	icon?: TaskStateIconName;
 	requires_context: boolean;
 }
 export interface TaskConfig {

--- a/client/react-frontend/src/styles/global.css
+++ b/client/react-frontend/src/styles/global.css
@@ -465,6 +465,25 @@ body,
 	height: 100%;
 }
 
+
+/* Scrollbar personalizado para modo claro o por defecto */
+::-webkit-scrollbar {
+	width: 8px;
+}
+
+::-webkit-scrollbar-track {
+	background: #f3f4f6;
+}
+
+::-webkit-scrollbar-thumb {
+	background: #d1d5db;
+	border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+	background: #9ca3af;
+}
+
 /* Scrollbar personalizado para modo oscuro */
 .dark ::-webkit-scrollbar {
 	width: 8px;

--- a/client/react-frontend/src/utils/util-components.tsx
+++ b/client/react-frontend/src/utils/util-components.tsx
@@ -1,44 +1,81 @@
-import { AlertCircle, CheckCircle, Clock } from "lucide-react";
+import {
+	AlertCircle,
+	CheckCircle,
+	Circle,
+	Clock,
+	PauseCircle,
+	PlayCircle,
+	XCircle,
+} from "lucide-react";
+import type {
+	TaskConfig,
+	TaskStateIconName,
+} from "@/components/projects/task-management/hooks/useTaskConfig";
 
-export const getStatusIcon = (status: string, taskConfig?: any) => {
-	// First try to find in dynamic config
-	if (taskConfig?.states) {
-		const stateConfig = taskConfig.states.find((s: any) => s.name === status);
-		if (stateConfig) {
-			// Return colored icon based on state config color
-			const iconColor = stateConfig.color;
-			switch (stateConfig.name.toLowerCase()) {
-				case "completado":
-					return (
-						<CheckCircle className="w-4 h-4" style={{ color: iconColor }} />
-					);
-				case "en progreso":
-					return <Clock className="w-4 h-4" style={{ color: iconColor }} />;
-				case "pendiente":
-					return (
-						<AlertCircle className="w-4 h-4" style={{ color: iconColor }} />
-					);
-				default:
-					return (
-						<div
-							className="w-4 h-4 rounded-full"
-							style={{ backgroundColor: iconColor }}
-						/>
-					);
-			}
-		}
-	}
-
-	// Fallback to static icons
-	switch (status) {
-		case "Completada":
-			return <CheckCircle className="w-4 h-4 text-green-500" />;
-
-		case "En progreso":
-			return <Clock className="w-4 h-4 text-blue-500" />;
-		case "Pendiente":
-			return <AlertCircle className="w-4 h-4 text-yellow-500" />;
+const resolveIconNameFromStatus = (status: string): TaskStateIconName => {
+	switch (status.trim().toLowerCase()) {
+		case "completado":
+		case "completada":
+			return "check-circle";
+		case "en progreso":
+			return "clock";
+		case "pendiente":
+			return "alert-circle";
+		case "cancelado":
+		case "cancelada":
+			return "x-circle";
+		case "suspendido":
+		case "pausado":
+			return "pause-circle";
 		default:
-			return null;
+			return "circle";
 	}
+};
+
+const renderIcon = (iconName: TaskStateIconName, color?: string) => {
+	const className = "w-4 h-4";
+	const style = color ? { color } : undefined;
+
+	switch (iconName) {
+		case "check-circle":
+			return <CheckCircle className={className} style={style} />;
+		case "clock":
+			return <Clock className={className} style={style} />;
+		case "pause-circle":
+			return <PauseCircle className={className} style={style} />;
+		case "x-circle":
+			return <XCircle className={className} style={style} />;
+		case "alert-circle":
+			return <AlertCircle className={className} style={style} />;
+		case "play-circle":
+			return <PlayCircle className={className} style={style} />;
+		case "circle":
+		default:
+			return <Circle className={className} style={style} />;
+	}
+};
+
+export const getStatusIcon = (status: string, taskConfig?: TaskConfig | null) => {
+	const stateConfig = taskConfig?.states?.find((state) => state.name === status);
+
+	if (stateConfig) {
+		const iconName = stateConfig.icon || resolveIconNameFromStatus(stateConfig.name);
+		return renderIcon(iconName, stateConfig.color);
+	}
+
+	const fallbackIcon = resolveIconNameFromStatus(status);
+	const fallbackColor =
+		fallbackIcon === "check-circle"
+			? "#22c55e"
+			: fallbackIcon === "clock"
+				? "#3b82f6"
+				: fallbackIcon === "alert-circle"
+					? "#eab308"
+					: fallbackIcon === "x-circle"
+						? "#ef4444"
+						: fallbackIcon === "pause-circle"
+							? "#6b7280"
+							: "#9ca3af";
+
+	return renderIcon(fallbackIcon, fallbackColor);
 };


### PR DESCRIPTION
### Motivation
- Facilitar el flujo de trabajo permitiendo cambiar el `status` de una tarea directamente desde la tabla sin abrir el diálogo de edición.
- Mantener sincronizado el estado cuando la misma tarea está abierta en el diálogo de vista para evitar inconsistencias visuales.
- Usar la configuración del proyecto para poblar las opciones de estado y caer en un fallback con los estados detectados en las tareas.

### Description
- Se añadió el handler `handleQuickStatusChange(taskId, status)` que actualiza la tarea via `updateTask` y sincroniza `selectedTask` si corresponde.
- Se introdujo `statusOptions` que utiliza `config.states` como primera fuente y `getUniqueStatuses()` como fallback.
- Se reemplazó el ícono estático de estado por un `Select` interactivo en la columna de estado tanto para la versión desktop como mobile, y se añadió `event.stopPropagation()` para evitar abrir el diálogo al interactuar con el selector.
- Archivo modificado: `client/react-frontend/src/components/projects/task-management/TaskManagement.tsx`.

### Testing
- Ejecutado `npx eslint src/components/projects/task-management/TaskManagement.tsx` y pasó correctamente para el archivo modificado. ✅
- Ejecutado `npm run build` en `client/react-frontend` y la compilación se realizó con éxito. ✅
- Ejecutado `npm run lint` a nivel de repo y la tarea falló por errores preexistentes en múltiples archivos fuera del alcance de este cambio, por lo que no se corrigieron en este PR. ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cf790f1ac8322ae9733be10453715)