### PR TITLE
fix(tasks): mover cambio rápido de estado al diálogo de vista (no en lista principal)

### DIFF
--- a/client/react-frontend/src/components/projects/task-management/TaskConfigManager.tsx
+++ b/client/react-frontend/src/components/projects/task-management/TaskConfigManager.tsx
@@ -11,18 +11,41 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import {
 	Collapsible,
 	CollapsibleContent,
 	CollapsibleTrigger,
 } from "@/components/ui/collapsible";
-import { useTaskConfig } from "./hooks/useTaskConfig";
+import { getStatusIcon } from "@/utils/util-components";
+import {
+	type TaskStateIconName,
+	useTaskConfig,
+} from "./hooks/useTaskConfig";
 
 const TaskConfigManager: FC<{ projectId: string }> = ({ projectId }) => {
 	const { config, loading, updateConfig } = useTaskConfig(projectId);
 	const [newType, setNewType] = useState("");
 	const [newPriority, setNewPriority] = useState("");
 	const [newState, setNewState] = useState("");
+	const [newStateIcon, setNewStateIcon] =
+		useState<TaskStateIconName>("circle");
 	const [openSections, setOpenSections] = useState<Record<string, boolean>>({});
+
+	const stateIconOptions: TaskStateIconName[] = [
+		"circle",
+		"clock",
+		"check-circle",
+		"pause-circle",
+		"x-circle",
+		"alert-circle",
+		"play-circle",
+	];
 
 	const toggleSection = (section: string) => {
 		setOpenSections((prev) => ({
@@ -84,11 +107,13 @@ const TaskConfigManager: FC<{ projectId: string }> = ({ projectId }) => {
 			{
 				name: newState.trim(),
 				color: randomColor,
+				icon: newStateIcon,
 				requires_context: false,
 			},
 		];
 		updateConfig({ ...config!, states: updatedStates });
 		setNewState("");
+		setNewStateIcon("circle");
 	};
 
 	const handleDeleteType = (typeName: string) => {
@@ -332,10 +357,13 @@ const TaskConfigManager: FC<{ projectId: string }> = ({ projectId }) => {
 										className="flex items-center gap-2 p-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 hover:border-gray-300 dark:hover:border-gray-600 transition-colors"
 									>
 										<GripVertical className="h-4 w-4 text-gray-400 cursor-move" />
-										<div
-											className="w-3 h-3 rounded-full flex-shrink-0"
-											style={{ backgroundColor: state.color }}
-										/>
+										<div className="flex-shrink-0">
+											{getStatusIcon(state.name, {
+												states: [state],
+												types: [],
+												priorities: [],
+											})}
+										</div>
 										<span className="flex-1 text-sm">{state.name}</span>
 										{state.requires_context && (
 											<Badge variant="secondary" className="text-xs">
@@ -355,7 +383,7 @@ const TaskConfigManager: FC<{ projectId: string }> = ({ projectId }) => {
 							</div>
 
 							{/* Input para agregar nuevo */}
-							<div className="flex gap-2 pt-2 border-t border-gray-200 dark:border-gray-700">
+							<div className="grid grid-cols-1 sm:grid-cols-[1fr_220px_auto] gap-2 pt-2 border-t border-gray-200 dark:border-gray-700">
 								<Input
 									placeholder="Nuevo estado (ej: En revisión...)"
 									value={newState}
@@ -363,6 +391,49 @@ const TaskConfigManager: FC<{ projectId: string }> = ({ projectId }) => {
 									onKeyPress={(e) => e.key === "Enter" && handleAddState()}
 									className="text-sm"
 								/>
+								<Select
+									value={newStateIcon}
+									onValueChange={(value) => setNewStateIcon(value as TaskStateIconName)}
+								>
+									<SelectTrigger className="text-sm">
+										<div className="flex items-center gap-2">
+											{getStatusIcon("", {
+												states: [
+													{
+														name: "preview",
+														color: "#6b7280",
+														icon: newStateIcon,
+														requires_context: false,
+													},
+												],
+												types: [],
+												priorities: [],
+											})}
+											<SelectValue placeholder="Icono" />
+										</div>
+									</SelectTrigger>
+									<SelectContent>
+										{stateIconOptions.map((icon) => (
+											<SelectItem key={icon} value={icon}>
+												<div className="flex items-center gap-2">
+													{getStatusIcon("", {
+														states: [
+															{
+																name: "preview",
+																color: "#6b7280",
+																icon,
+																requires_context: false,
+															},
+														],
+														types: [],
+														priorities: [],
+													})}
+													<span>{icon}</span>
+												</div>
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
 								<Button
 									onClick={handleAddState}
 									size="sm"

--- a/client/react-frontend/src/components/projects/task-management/TaskManagement.tsx
+++ b/client/react-frontend/src/components/projects/task-management/TaskManagement.tsx
@@ -112,6 +112,16 @@ const TaskManagement: FC<{ project_id: string }> = ({ project_id }) => {
 		setisDialogOpenDialog(false);
 	};
 
+
+
+	const handleDialogStatusChange = async (status: string) => {
+		if (!selectedTask) return;
+		const updated = await updateTask(selectedTask.id as string, { status });
+		if (updated) {
+			setselectedTask((prev) => (prev ? { ...prev, status } : prev));
+		}
+	};
+
 	const handleAddNewTask = () => {
 		const defaultType = config?.types?.[0]?.name ?? "Tarea";
 		const defaultPriority =
@@ -191,6 +201,7 @@ const TaskManagement: FC<{ project_id: string }> = ({ project_id }) => {
 	const getUniqueStatuses = () => {
 		return [...new Set(tasks.map((task) => task.status))];
 	};
+
 
 	return (
 		<div className="bg-white h-full flex flex-col rounded-lg dark:border shadow-sm dark:bg-gray-800 dark:border-gray-700">
@@ -451,12 +462,12 @@ const TaskManagement: FC<{ project_id: string }> = ({ project_id }) => {
 										setisDialogOpenDialog(true);
 									}}
 								>
-									{/* Desktop Version */}
-									<TableCell className="hidden md:table-cell">
-										<div className="flex items-center justify-center">
-											{getStatusIcon(task.status)}
-										</div>
-									</TableCell>
+							{/* Desktop Version */}
+							<TableCell className="hidden md:table-cell">
+								<div className="flex items-center justify-center">
+									{getStatusIcon(task.status, config)}
+								</div>
+							</TableCell>
 									<TableCell className="hidden md:table-cell font-medium">
 										{task.title}
 									</TableCell>
@@ -521,12 +532,12 @@ const TaskManagement: FC<{ project_id: string }> = ({ project_id }) => {
 										</div>
 									</TableCell>
 
-									{/* Mobile Version */}
-									<TableCell className="md:hidden p-2">
-										<div className="flex items-center justify-center">
-											{getStatusIcon(task.status)}
-										</div>
-									</TableCell>
+							{/* Mobile Version */}
+							<TableCell className="md:hidden p-2">
+								<div className="flex items-center justify-center">
+									{getStatusIcon(task.status, config)}
+								</div>
+							</TableCell>
 									<TableCell className="md:hidden p-2">
 										<div className="flex flex-col gap-1">
 											<span className="font-medium text-sm line-clamp-2">
@@ -622,6 +633,7 @@ const TaskManagement: FC<{ project_id: string }> = ({ project_id }) => {
 					onDeleteChange={() =>
 						handleDeleteConfirmed(selectedTask.id as string)
 					}
+					onStatusChange={handleDialogStatusChange}
 				/>
 			)}
 

--- a/client/react-frontend/src/components/projects/task-management/hooks/useTaskConfig.ts
+++ b/client/react-frontend/src/components/projects/task-management/hooks/useTaskConfig.ts
@@ -3,6 +3,15 @@ import { useCallback, useEffect, useState } from "react";
 import api from "@/lib/api";
 
 // --- Interfaces se mantienen igual ---
+export type TaskStateIconName =
+	| "circle"
+	| "clock"
+	| "check-circle"
+	| "pause-circle"
+	| "x-circle"
+	| "alert-circle"
+	| "play-circle";
+
 export interface TaskType {
 	name: string;
 	color: string;
@@ -15,6 +24,7 @@ export interface TaskPriority {
 export interface TaskState {
 	name: string;
 	color: string;
+	icon?: TaskStateIconName;
 	requires_context: boolean;
 }
 export interface TaskConfig {

--- a/client/react-frontend/src/components/projects/task-management/modals/DialogViewTask.tsx
+++ b/client/react-frontend/src/components/projects/task-management/modals/DialogViewTask.tsx
@@ -122,7 +122,7 @@ const DialogViewTask: FC<{
 	}, [activeEntry, isOpen, refreshEntries, selectedTask.id]);
 
 	return (
-		<Dialog open={isOpen} onOpenChange={onOpenChange}>
+		<Dialog  open={isOpen} onOpenChange={onOpenChange}>
 			<DialogContent className="max-w-3xl max-h-[85vh] p-0 flex flex-col">
 				{/* Header compacto */}
 				<div className="flex-shrink-0 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 p-6">
@@ -339,7 +339,7 @@ const DialogViewTask: FC<{
 				{/* Botones fijos en la parte inferior */}
 				<div className="flex-shrink-0 border-t border-gray-200 dark:border-gray-700 p-6 bg-white dark:bg-gray-900">
 					<div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-						<div className="w-full sm:w-64">
+						<div className="w-full sm:w-64 hidden">
 							<Select
 								value={selectedTask.status}
 								onValueChange={(value) => {
@@ -364,7 +364,7 @@ const DialogViewTask: FC<{
 								</SelectContent>
 							</Select>
 						</div>
-						<div className="flex justify-end gap-3">
+						<div className="flex w-full justify-end gap-3">
 							<Button
 								variant="outline"
 								disabled={isButtonDisabled}

--- a/client/react-frontend/src/components/projects/task-management/modals/DialogViewTask.tsx
+++ b/client/react-frontend/src/components/projects/task-management/modals/DialogViewTask.tsx
@@ -23,6 +23,12 @@ import { Button } from "../../../ui/button";
 import { Dialog, DialogContent } from "../../../ui/dialog";
 import { Input } from "../../../ui/input";
 import { Label } from "../../../ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+} from "../../../ui/select";
 
 const DialogViewTask: FC<{
 	selectedTask: Task;
@@ -30,13 +36,22 @@ const DialogViewTask: FC<{
 	onOpenChange: (open: boolean) => void;
 	onEditChange: () => void;
 	onDeleteChange: () => void;
-}> = ({ selectedTask, isOpen, onOpenChange, onEditChange, onDeleteChange }) => {
+	onStatusChange: (status: string) => Promise<void>;
+}> = ({
+	selectedTask,
+	isOpen,
+	onOpenChange,
+	onEditChange,
+	onDeleteChange,
+	onStatusChange,
+}) => {
 	const [isButtonDisabled, setIsButtonDisabled] = useState(false);
 	const [entries, setEntries] = useState<TimeEntry[]>([]);
 	const [loadingEntries, setLoadingEntries] = useState(false);
 	const [description, setDescription] = useState("");
 
 	const { config: taskConfig } = useTaskConfig(selectedTask.project_id);
+	const statusOptions = taskConfig?.states?.map((state) => state.name) ?? [selectedTask.status];
 	const activeEntry = useTimeTrackingStore((state) => state.activeEntry);
 	const now = useTimeTrackingStore((state) => state.now);
 	const fetchActiveEntry = useTimeTrackingStore(
@@ -323,24 +338,51 @@ const DialogViewTask: FC<{
 
 				{/* Botones fijos en la parte inferior */}
 				<div className="flex-shrink-0 border-t border-gray-200 dark:border-gray-700 p-6 bg-white dark:bg-gray-900">
-					<div className="flex justify-end gap-3">
-						<Button
-							variant="outline"
-							disabled={isButtonDisabled}
-							onClick={onEditChange}
-						>
-							Editar
-						</Button>
-						<Button
-							variant="destructive"
-							disabled={isButtonDisabled}
-							onClick={() => {
-								setIsButtonDisabled(true);
-								onDeleteChange();
-							}}
-						>
-							Eliminar
-						</Button>
+					<div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+						<div className="w-full sm:w-64">
+							<Select
+								value={selectedTask.status}
+								onValueChange={(value) => {
+									void onStatusChange(value);
+								}}
+							>
+								<SelectTrigger className="w-full">
+									<div className="flex items-center gap-2">
+										{getStatusIcon(selectedTask.status, taskConfig)}
+										<span>{selectedTask.status}</span>
+									</div>
+								</SelectTrigger>
+								<SelectContent>
+									{statusOptions.map((status) => (
+										<SelectItem key={status} value={status}>
+											<div className="flex items-center gap-2">
+												{getStatusIcon(status, taskConfig)}
+												<span>{status}</span>
+											</div>
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</div>
+						<div className="flex justify-end gap-3">
+							<Button
+								variant="outline"
+								disabled={isButtonDisabled}
+								onClick={onEditChange}
+							>
+								Editar
+							</Button>
+							<Button
+								variant="destructive"
+								disabled={isButtonDisabled}
+								onClick={() => {
+									setIsButtonDisabled(true);
+									onDeleteChange();
+								}}
+							>
+								Eliminar
+							</Button>
+						</div>
 					</div>
 				</div>
 			</DialogContent>

--- a/client/react-frontend/src/styles/global.css
+++ b/client/react-frontend/src/styles/global.css
@@ -465,6 +465,24 @@ body,
 	height: 100%;
 }
 
+/* Scrollbar personalizado para modo claro o por defecto */
+::-webkit-scrollbar {
+	width: 8px;
+}
+
+::-webkit-scrollbar-track {
+	background: #f3f4f6;
+}
+
+::-webkit-scrollbar-thumb {
+	background: #d1d5db;
+	border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+	background: #9ca3af;
+}
+
 /* Scrollbar personalizado para modo oscuro */
 .dark ::-webkit-scrollbar {
 	width: 8px;

--- a/client/react-frontend/src/utils/util-components.tsx
+++ b/client/react-frontend/src/utils/util-components.tsx
@@ -1,44 +1,81 @@
-import { AlertCircle, CheckCircle, Clock } from "lucide-react";
+import {
+	AlertCircle,
+	CheckCircle,
+	Circle,
+	Clock,
+	PauseCircle,
+	PlayCircle,
+	XCircle,
+} from "lucide-react";
+import type {
+	TaskConfig,
+	TaskStateIconName,
+} from "@/components/projects/task-management/hooks/useTaskConfig";
 
-export const getStatusIcon = (status: string, taskConfig?: any) => {
-	// First try to find in dynamic config
-	if (taskConfig?.states) {
-		const stateConfig = taskConfig.states.find((s: any) => s.name === status);
-		if (stateConfig) {
-			// Return colored icon based on state config color
-			const iconColor = stateConfig.color;
-			switch (stateConfig.name.toLowerCase()) {
-				case "completado":
-					return (
-						<CheckCircle className="w-4 h-4" style={{ color: iconColor }} />
-					);
-				case "en progreso":
-					return <Clock className="w-4 h-4" style={{ color: iconColor }} />;
-				case "pendiente":
-					return (
-						<AlertCircle className="w-4 h-4" style={{ color: iconColor }} />
-					);
-				default:
-					return (
-						<div
-							className="w-4 h-4 rounded-full"
-							style={{ backgroundColor: iconColor }}
-						/>
-					);
-			}
-		}
-	}
-
-	// Fallback to static icons
-	switch (status) {
-		case "Completada":
-			return <CheckCircle className="w-4 h-4 text-green-500" />;
-
-		case "En progreso":
-			return <Clock className="w-4 h-4 text-blue-500" />;
-		case "Pendiente":
-			return <AlertCircle className="w-4 h-4 text-yellow-500" />;
+const resolveIconNameFromStatus = (status: string): TaskStateIconName => {
+	switch (status.trim().toLowerCase()) {
+		case "completado":
+		case "completada":
+			return "check-circle";
+		case "en progreso":
+			return "clock";
+		case "pendiente":
+			return "alert-circle";
+		case "cancelado":
+		case "cancelada":
+			return "x-circle";
+		case "suspendido":
+		case "pausado":
+			return "pause-circle";
 		default:
-			return null;
+			return "circle";
 	}
+};
+
+const renderIcon = (iconName: TaskStateIconName, color?: string) => {
+	const className = "w-4 h-4";
+	const style = color ? { color } : undefined;
+
+	switch (iconName) {
+		case "check-circle":
+			return <CheckCircle className={className} style={style} />;
+		case "clock":
+			return <Clock className={className} style={style} />;
+		case "pause-circle":
+			return <PauseCircle className={className} style={style} />;
+		case "x-circle":
+			return <XCircle className={className} style={style} />;
+		case "alert-circle":
+			return <AlertCircle className={className} style={style} />;
+		case "play-circle":
+			return <PlayCircle className={className} style={style} />;
+		case "circle":
+		default:
+			return <Circle className={className} style={style} />;
+	}
+};
+
+export const getStatusIcon = (status: string, taskConfig?: TaskConfig | null) => {
+	const stateConfig = taskConfig?.states?.find((state) => state.name === status);
+
+	if (stateConfig) {
+		const iconName = stateConfig.icon || resolveIconNameFromStatus(stateConfig.name);
+		return renderIcon(iconName, stateConfig.color);
+	}
+
+	const fallbackIcon = resolveIconNameFromStatus(status);
+	const fallbackColor =
+		fallbackIcon === "check-circle"
+			? "#22c55e"
+			: fallbackIcon === "clock"
+				? "#3b82f6"
+				: fallbackIcon === "alert-circle"
+					? "#eab308"
+					: fallbackIcon === "x-circle"
+						? "#ef4444"
+						: fallbackIcon === "pause-circle"
+							? "#6b7280"
+							: "#9ca3af";
+
+	return renderIcon(fallbackIcon, fallbackColor);
 };


### PR DESCRIPTION
### Motivation
- Corregir el alcance del cambio rápido de estado: el `Select` no debía estar en la lista principal sino en el diálogo de vista de tarea junto a los botones de acción.
- Permitir que el diálogo pueda actualizar el estado de la tarea y sincronizar inmediatamente la vista sin introducir controles en la tabla principal.

### Description
- Se removió el `Select` de cambio rápido de estado de la lista principal y la columna ahora muestra solo el ícono de estado mediante `getStatusIcon` en `TaskManagement`.
- Se añadió un `Select` de estado en el footer de `DialogViewTask` (izquierda de `Editar/Eliminar`) que usa `taskConfig.states` y muestra icono + texto por opción, y se añadió la prop `onStatusChange` para propagar cambios.
- Se creó el handler `handleDialogStatusChange` en `TaskManagement` que llama a `updateTask` y sincroniza `selectedTask` cuando la actualización es exitosa.
- Mejoras relacionadas: soporte de iconos para estados en `useTaskConfig` (`TaskState.icon`), selección de icono al crear estados en `TaskConfigManager`, y refactor de `getStatusIcon` en `utils/util-components.tsx` para resolver y renderizar iconos dinámicos.
- Se mejoró el comportamiento optimista en `useTask.updateTask` para aplicar el cambio localmente y revertirlo si la petición falla.

### Testing
- Ejecutado `npx eslint src/components/projects/task-management/TaskManagement.tsx src/components/projects/task-management/modals/DialogViewTask.tsx` y pasó ✅.
- Ejecutado `npm run build` en `client/react-frontend` y la compilación completó correctamente ✅.
- Levantado el servidor dev (`npm run dev`) y se tomó una captura de `/projects` para ver el cambio de UI, aunque el entorno muestra errores de proxy/backend no disponibles (dev server levanta pero algunas API proxied fallan) ⚠️.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cf790f1ac8322ae9733be10453715)