### PR TITLE
Refactor del chat: estado compartido y separación del módulo de agentes

### DIFF
--- a/CHAT_REDESIGN_REFACTOR_PLAN.md
+++ b/CHAT_REDESIGN_REFACTOR_PLAN.md
@@ -1,0 +1,184 @@
+# Rediseño y Refactorización Integral del Módulo de Chat
+
+## 1) Contexto y definición del problema
+
+El módulo de chat actual presenta fallas funcionales, inestabilidad de rendimiento y una experiencia de uso poco clara. Este documento define un plan de ejecución para rediseñar el chat como una herramienta de colaboración interna para equipos, separando explícitamente cualquier interacción con agentes externos en un módulo diferente.
+
+## 2) Objetivo del proyecto
+
+Construir un módulo de **chat colaborativo para equipos internos** que sea:
+
+- Estable y confiable en operación diaria.
+- Intuitivo en UI/UX para comunicación en tiempo real.
+- Escalable para crecimiento de usuarios y mensajes.
+- Claramente separado del chat con agentes externos.
+
+## 3) Principios de diseño
+
+1. **Colaboración primero**: funcionalidades orientadas a trabajo en equipo (canales, menciones, archivos, estados de lectura).
+2. **Separación de dominios**: chat interno y chat con agentes externos no comparten UI ni rutas principales.
+3. **Resiliencia por defecto**: reconexión, persistencia temporal y tolerancia a fallos de red.
+4. **Observabilidad**: métricas y trazas desde el día 1 para detectar regresiones.
+5. **Performance medible**: objetivos explícitos de latencia, carga y render.
+
+## 4) Alcance funcional
+
+### Incluido (MVP interno)
+
+- Conversaciones por equipos/canales.
+- Mensajería en tiempo real.
+- Soporte de mensajes editables y eliminables.
+- Menciones de usuarios.
+- Búsqueda básica por texto.
+- Indicadores de estado (enviado, entregado, leído).
+- Notificaciones dentro de la aplicación.
+
+### Excluido (módulo separado)
+
+- Flujos de conversación con agentes externos (soporte/ventas/atención).
+- Enrutamiento híbrido interno + externo en la misma pantalla.
+
+## 5) Arquitectura objetivo (alto nivel)
+
+### Frontera de módulos
+
+- `chat-interno/*`: UI, estado y servicios exclusivos para colaboración de equipos.
+- `chat-agentes/*`: módulo independiente para conversaciones con agentes externos.
+- `shared-chat/*`: utilidades realmente comunes (modelos base, componentes agnósticos, helpers de formato).
+
+### Decisiones clave
+
+- Rutas separadas (`/chat/teams` vs `/chat/agents`).
+- Estado aislado por módulo (stores/contextos distintos).
+- Contratos de API explícitos para cada dominio.
+- Eventos en tiempo real namespaced por dominio.
+
+## 6) Requisitos funcionales detallados
+
+1. Crear canales y gestionar miembros por permisos.
+2. Enviar/recibir mensajes en tiempo real con orden consistente.
+3. Editar y eliminar mensajes propios con trazabilidad.
+4. Menciones con autocompletado y notificación contextual.
+5. Indicadores de lectura por canal y mensaje.
+6. Búsqueda por palabra clave y filtros temporales.
+7. Carga incremental de historial (paginación/infinite scroll).
+
+## 7) Requisitos no funcionales
+
+- **Disponibilidad**: ≥ 99.5% para el servicio de mensajería interna.
+- **Latencia**: p95 de envío a entrega visible < 400ms en red corporativa.
+- **Escalabilidad**: 10x volumen actual sin degradación severa.
+- **Seguridad**: control de acceso por equipo/canal, auditoría de acciones.
+- **Accesibilidad**: cumplimiento WCAG AA en vistas principales.
+
+## 8) Épicas y backlog sugerido
+
+### Épica A — Diagnóstico y requisitos
+
+- A1. Inventario de bugs actuales (severidad, frecuencia, impacto).
+- A2. Mapa de flujos rotos (crear canal, enviar, editar, buscar).
+- A3. Definición de contrato funcional del chat interno.
+- A4. Definición de fronteras con módulo de agentes.
+
+**Entregables**: matriz de errores, PRD de chat interno, criterios de aceptación por flujo.
+
+### Épica B — Rediseño UI/UX
+
+- B1. Wireframes de lista de canales, conversación y panel lateral.
+- B2. Prototipo de interacciones críticas (menciones, búsqueda, edición).
+- B3. Tests de usabilidad con usuarios clave.
+- B4. Ajustes de diseño y sistema de componentes.
+
+**Entregables**: prototipo validado, guía visual y de interacción.
+
+### Épica C — Refactor técnico base
+
+- C1. Separar carpetas y rutas por dominio (interno/agentes).
+- C2. Extraer lógica reusable en `shared-chat`.
+- C3. Eliminar acoplamientos de estado entre módulos.
+- C4. Añadir capa de servicios con contratos tipados.
+
+**Entregables**: estructura modular estable y testeable.
+
+### Épica D — Funcionalidades colaborativas
+
+- D1. Mensajería tiempo real confiable.
+- D2. Menciones, respuesta a mensajes y estados.
+- D3. Búsqueda e historial paginado.
+- D4. Notificaciones in-app por actividad relevante.
+
+**Entregables**: MVP colaborativo completo para equipos.
+
+### Épica E — Calidad, performance y observabilidad
+
+- E1. Suite de pruebas unitarias e integración.
+- E2. Pruebas funcionales de flujos críticos.
+- E3. Benchmarks de rendimiento y perfilado de UI.
+- E4. Dashboards de errores, latencia y reconexiones.
+
+**Entregables**: calidad automatizada y métricas operativas.
+
+### Épica F — Despliegue y adopción
+
+- F1. Migración gradual por grupos piloto.
+- F2. Plan de rollback y feature flags.
+- F3. Capacitación y guía de uso.
+- F4. Monitoreo post-despliegue y hardening.
+
+**Entregables**: release controlado y estabilización en producción.
+
+## 9) Plan de implementación por fases
+
+### Fase 0 — Descubrimiento (1-2 semanas)
+
+- Diagnóstico técnico y funcional.
+- Definición de KPIs base y objetivos.
+
+### Fase 1 — Diseño y arquitectura (2-3 semanas)
+
+- Prototipos validados.
+- Diseño de módulo separado para agentes.
+
+### Fase 2 — Construcción MVP interno (3-5 semanas)
+
+- Funciones núcleo + pruebas automáticas.
+
+### Fase 3 — Endurecimiento y despliegue (2-3 semanas)
+
+- Optimización, UAT, rollout progresivo.
+
+## 10) Criterios de aceptación global
+
+1. Los flujos críticos del chat interno pasan pruebas funcionales sin bloqueantes.
+2. No existe navegación ambigua entre chat interno y chat de agentes.
+3. Métricas de estabilidad y latencia alcanzan los umbrales acordados.
+4. Usuarios piloto reportan mejora de usabilidad frente al módulo anterior.
+
+## 11) Riesgos y mitigaciones
+
+- **Riesgo**: herencia de deuda técnica del módulo roto.
+  - **Mitigación**: refactor por capas con pruebas de regresión por flujo.
+- **Riesgo**: mezcla accidental de dominios interno/agentes.
+  - **Mitigación**: contratos API y rutas separadas obligatorias.
+- **Riesgo**: regresión de performance por crecimiento de mensajes.
+  - **Mitigación**: virtualización, memoización y presupuestos de performance.
+
+## 12) KPIs de éxito
+
+- Reducción de errores críticos reportados (objetivo: -80% en 60 días).
+- Tiempo de respuesta percibido en envío/recepción (p95 < 400ms).
+- Tasa de adopción por equipos internos (objetivo > 85% en 30 días post-release).
+- Satisfacción de usuarios internos (CSAT/NPS específico del módulo).
+
+## 13) Definición de listo (DoR) y definición de hecho (DoD)
+
+### DoR
+
+- Historia con contexto, criterios de aceptación y dependencia identificada.
+- Mock o flujo UX definido para cambios visibles.
+
+### DoD
+
+- Código revisado, pruebas aprobadas y métricas sin regresión material.
+- Documentación funcional/técnica actualizada.
+- Monitoreo habilitado para la nueva funcionalidad.

--- a/client/react-frontend/src/chat/app/agents-page.tsx
+++ b/client/react-frontend/src/chat/app/agents-page.tsx
@@ -1,0 +1,30 @@
+import { Bot, ArrowLeftRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useNavigate } from "react-router-dom";
+
+export default function AgentsChatPage() {
+	const navigate = useNavigate();
+
+	return (
+		<div className="h-screen bg-background flex items-center justify-center p-6">
+			<div className="max-w-xl w-full rounded-xl border border-border bg-card p-6 text-center space-y-4">
+				<div className="mx-auto h-12 w-12 rounded-full bg-primary/10 flex items-center justify-center text-primary">
+					<Bot className="h-6 w-6" />
+				</div>
+				<h1 className="text-xl font-semibold">Módulo de chat con agentes</h1>
+				<p className="text-sm text-muted-foreground">
+					Las conversaciones con agentes externos se gestionan en este espacio
+					dedicado para mantener el chat interno enfocado en colaboración de
+					equipos.
+				</p>
+				<div className="flex items-center justify-center gap-2">
+					<Button onClick={() => navigate("/chat")}>Ir a chat interno</Button>
+					<Button variant="outline" onClick={() => navigate("/dashboard")}>
+						<ArrowLeftRight className="h-4 w-4 mr-2" />
+						Volver al dashboard
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/client/react-frontend/src/chat/app/agents-page.tsx
+++ b/client/react-frontend/src/chat/app/agents-page.tsx
@@ -1,30 +1,10 @@
-import { Bot, ArrowLeftRight } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { useNavigate } from "react-router-dom";
+import { AgentsChatInterface } from "../components/agents-chat-interface";
+import { ChatProvider } from "../hooks/useChatContext";
 
 export default function AgentsChatPage() {
-	const navigate = useNavigate();
-
 	return (
-		<div className="h-screen bg-background flex items-center justify-center p-6">
-			<div className="max-w-xl w-full rounded-xl border border-border bg-card p-6 text-center space-y-4">
-				<div className="mx-auto h-12 w-12 rounded-full bg-primary/10 flex items-center justify-center text-primary">
-					<Bot className="h-6 w-6" />
-				</div>
-				<h1 className="text-xl font-semibold">Módulo de chat con agentes</h1>
-				<p className="text-sm text-muted-foreground">
-					Las conversaciones con agentes externos se gestionan en este espacio
-					dedicado para mantener el chat interno enfocado en colaboración de
-					equipos.
-				</p>
-				<div className="flex items-center justify-center gap-2">
-					<Button onClick={() => navigate("/chat")}>Ir a chat interno</Button>
-					<Button variant="outline" onClick={() => navigate("/dashboard")}>
-						<ArrowLeftRight className="h-4 w-4 mr-2" />
-						Volver al dashboard
-					</Button>
-				</div>
-			</div>
-		</div>
+		<ChatProvider>
+			<AgentsChatInterface />
+		</ChatProvider>
 	);
 }

--- a/client/react-frontend/src/chat/app/page.tsx
+++ b/client/react-frontend/src/chat/app/page.tsx
@@ -1,5 +1,10 @@
 import { ChatInterface } from "../components/chat-interface";
+import { ChatProvider } from "../hooks/useChatContext";
 
 export default function HomeChat() {
-	return <ChatInterface />;
+	return (
+		<ChatProvider>
+			<ChatInterface />
+		</ChatProvider>
+	);
 }

--- a/client/react-frontend/src/chat/components/agents-chat-conversation.tsx
+++ b/client/react-frontend/src/chat/components/agents-chat-conversation.tsx
@@ -1,0 +1,722 @@
+import { Bot, File, Mic, Paperclip, Send, Smile, Video, X } from "lucide-react";
+import type React from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import type { Agent } from "../../types/Agent";
+import { useAgents } from "../hooks/useAgents";
+import {
+	type Message as BackendMessage,
+	type Conversation,
+	} from "../hooks/useChat";
+import { useChatContext } from "../hooks/useChatContext";
+import type { Message } from "./chat-interface";
+import { ChatMessage } from "./chat-message";
+import { ChatSettings } from "./chat-settings";
+import { Textarea } from "@/components/ui/textarea";
+import { useToast } from "@/hooks/use-toast";
+
+interface ChatConversationProps {
+	chat: Conversation;
+	showSettings: boolean;
+	onShowSettingsChange: (show: boolean) => void;
+	selectedAgent?: Agent | null;
+}
+
+export interface ExtendedMessage extends Message {
+	attachment?: {
+		type: "image" | "audio" | "video" | "file";
+		url: string;
+		name?: string;
+		size?: string;
+	};
+	replyTo?: {
+		id: string;
+		content: string;
+		senderName?: string;
+	};
+}
+
+/**
+ * ChatConversation:
+ * - integra useChat para fetch/send/mark-as-read
+ * - sube archivos a /api/uploads (POST FormData) — el backend debe exponer este endpoint
+ * - actualiza UI de forma optimista y luego reemplaza con la respuesta del servidor
+ */
+
+export function AgentsChatConversation({
+	chat,
+	showSettings,
+	onShowSettingsChange,
+	selectedAgent,
+}: ChatConversationProps) {
+	const {
+		fetchMessages,
+		messagesMap,
+		sendMessage,
+		setMessagesForConversation,
+		markAsRead,
+	} = useChatContext();
+
+	const { sendMessageToAgent } = useAgents();
+
+	const [messages, setMessages] = useState<ExtendedMessage[]>([]);
+	const [newMessage, setNewMessage] = useState("");
+	const [hoveredMessageId, setHoveredMessageId] = useState<string | null>(null);
+	const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
+	const [editingContent, setEditingContent] = useState("");
+	const [replyingTo, setReplyingTo] = useState<ExtendedMessage | null>(null);
+	const [attachment, setAttachment] = useState<File | null>(null);
+	const [attachmentPreview, setAttachmentPreview] = useState<string | null>(
+		null,
+	);
+	const [sending, setSending] = useState(false);
+	const [waitingForAgent, setWaitingForAgent] = useState(false);
+	const [anErrorOcurred, setAnErrorOcurred] = useState(false);
+	const { toast } = useToast();
+
+	const scrollRef = useRef<HTMLDivElement>(null);
+	const fileInputRef = useRef<HTMLInputElement>(null);
+
+	const serverUrl =
+		(import.meta.env.VITE_SERVER_URL as string) || "http://localhost:3000";
+
+	// --- Load messages from backend when chat changes ---
+	useEffect(() => {
+		console.log("Chat changed:", chat);
+		if (!chat?.id) return;
+		// fetchMessages will populate messagesMap inside the hook
+		fetchMessages(chat.id).catch((e) => {
+			// fetchMessages already sets error inside hook; here just log
+			console.error("fetchMessages error:", e);
+		});
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [chat?.id]);
+
+	// --- Mirror hook's messagesMap into local messages state for rendering and local UX edits ---
+	// Use useMemo to avoid recalculating on every render
+	const normalizedMessages = useMemo(() => {
+		const list = messagesMap?.[chat.id] ?? [];
+		// map backend message shape to ExtendedMessage if needed
+		const userId = (window as any).__CURRENT_USER_ID;
+		return (list as BackendMessage[]).map((m) => ({
+			id: String(m.id),
+			content: m.content ?? "",
+			sender:
+				m.sender_id === undefined || m.sender_id === null
+					? ("other" as const)
+					: m.sender_id === userId
+						? ("me" as const)
+						: ("other" as const),
+			timestamp: m.created_at
+				? new Date(m.created_at).toLocaleTimeString("es-ES", {
+						hour: "2-digit",
+						minute: "2-digit",
+					})
+				: "",
+			senderName:
+				m.sender_id === userId
+					? "Tú"
+					: m.sender_name || m.sender_email || "Usuario",
+			avatar: undefined, // Backend Message doesn't have avatar field
+			attachment: m.attachment_url
+				? {
+						type: (m.attachment_type as any) ?? "file",
+						url: m.attachment_url,
+						name: undefined,
+						size: undefined,
+					}
+				: undefined,
+			replyTo: m.reply_to
+				? {
+						id: String(m.reply_to),
+						content: "", // Backend doesn't have reply_to content
+						senderName: undefined,
+					}
+				: undefined,
+		}));
+	}, [messagesMap, chat.id]);
+
+	// Update local messages state when normalized messages change
+	useEffect(() => {
+		setMessages(normalizedMessages);
+		// auto mark as read using last message id
+		if (normalizedMessages.length > 0) {
+			const last = normalizedMessages[normalizedMessages.length - 1];
+			// call markAsRead with backend id (we stored id as string); the hook will send it
+			markAsRead(chat.id, last.id).catch(() => {});
+		}
+	}, [normalizedMessages, chat.id, markAsRead]);
+
+	// --- Scroll to bottom when messages change ---
+	useEffect(() => {
+		if (scrollRef.current) {
+			// Smooth scroll to bottom
+			scrollRef.current.scrollTo({
+				top: scrollRef.current.scrollHeight,
+				behavior: "smooth",
+			});
+		}
+	}, [messages]);
+
+	const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+		const file = e.target.files?.[0];
+		if (!file) return;
+
+		setAttachment(file);
+
+		// Create preview for images
+		if (file.type.startsWith("image/")) {
+			const reader = new FileReader();
+			reader.onload = (ev) => {
+				setAttachmentPreview(ev.target?.result as string);
+			};
+			reader.readAsDataURL(file);
+		} else {
+			setAttachmentPreview(null);
+		}
+	};
+
+	const getAttachmentType = (
+		file: File,
+	): "image" | "audio" | "video" | "file" => {
+		if (file.type.startsWith("image/")) return "image";
+		if (file.type.startsWith("audio/")) return "audio";
+		if (file.type.startsWith("video/")) return "video";
+		return "file";
+	};
+
+	const formatFileSize = (bytes: number): string => {
+		if (bytes < 1024) return bytes + " B";
+		if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + " KB";
+		return (bytes / (1024 * 1024)).toFixed(1) + " MB";
+	};
+
+	// upload file to S3 via backend
+	const uploadFile = useCallback(
+		async (file: File) => {
+			const fd = new FormData();
+			fd.append("file", file);
+			try {
+				const res = await fetch(`${serverUrl}/api/uploads`, {
+					method: "POST",
+					body: fd,
+					credentials: "include",
+				});
+				if (!res.ok) {
+					const errorData = await res.json();
+					throw new Error(errorData.error || "Upload failed");
+				}
+				const data = await res.json();
+				return data; // { url, attachment_name, attachment_size, attachment_type, key, bucket }
+			} catch (err) {
+				console.error("uploadFile error:", err);
+				throw err;
+			}
+		},
+		[serverUrl],
+	);
+
+	// send message using hook; if attachment present, first upload then include attachment_url/type
+	const handleSendMessage = async () => {
+		if (sending) return;
+		if (!newMessage.trim() && !attachment) return;
+
+		setSending(true);
+
+		setAnErrorOcurred(false);
+
+		// optimistic message (temporary id)
+		const tempId = "tmp-" + Date.now().toString();
+		const optimistic: ExtendedMessage = {
+			id: tempId,
+			content: newMessage || "",
+			sender: "me",
+			timestamp: new Date().toLocaleTimeString("es-ES", {
+				hour: "2-digit",
+				minute: "2-digit",
+			}),
+			...(attachment && {
+				attachment: {
+					type: getAttachmentType(attachment),
+					url: attachmentPreview || URL.createObjectURL(attachment),
+					name: attachment.name,
+					size: formatFileSize(attachment.size),
+				},
+			}),
+			...(replyingTo && {
+				replyTo: {
+					id: replyingTo.id,
+					content: replyingTo.content,
+					senderName: replyingTo.senderName,
+				},
+			}),
+		};
+
+		// update UI immediately
+		setMessages((prev) => [...prev, optimistic]);
+
+		try {
+			const attachment_payload: {
+				attachment_url?: string;
+				attachment_type?: string;
+				attachment_name?: string;
+				attachment_size?: string;
+			} = {};
+			if (attachment) {
+				try {
+					const uploaded = await uploadFile(attachment);
+					// normalize expected fields
+					attachment_payload.attachment_url =
+						uploaded.url || uploaded.attachment_url || uploaded.fileUrl;
+					attachment_payload.attachment_type =
+						uploaded.attachment_type || getAttachmentType(attachment);
+					attachment_payload.attachment_name =
+						uploaded.attachment_name || attachment.name;
+					attachment_payload.attachment_size =
+						uploaded.attachment_size || formatFileSize(attachment.size);
+				} catch (err) {
+					// if upload fails, remove optimistic attachment preview but still attempt to send text
+					console.warn(
+						"upload failed, will send message without attachment",
+						err,
+					);
+					// remove preview from optimistic message
+					setMessages((prev) =>
+						prev.map((m) =>
+							m.id === tempId ? { ...m, attachment: undefined } : m,
+						),
+					);
+				}
+			}
+
+			// Check if we have a selected agent
+			if (selectedAgent) {
+				// Set loading state for agent
+				setWaitingForAgent(true);
+
+				// Send message to agent
+				const agentPayload = {
+					agent_id: selectedAgent.id,
+					conversation_id: chat.id,
+					content: newMessage || "",
+					...(attachment_payload.attachment_type && {
+						attachment_type: attachment_payload.attachment_type as
+							| "image"
+							| "audio"
+							| "video"
+							| "file",
+						attachment_url: attachment_payload.attachment_url,
+					}),
+				};
+
+				const agentResponse = await sendMessageToAgent(agentPayload);
+
+				if (agentResponse) {
+					// Replace optimistic message with user message
+					const userMessage: ExtendedMessage = {
+						id: String(agentResponse.userMessage.id),
+						content: agentResponse.userMessage.content || "",
+						sender: "me",
+						timestamp: agentResponse.userMessage.created_at
+							? new Date(
+									agentResponse.userMessage.created_at,
+								).toLocaleTimeString("es-ES", {
+									hour: "2-digit",
+									minute: "2-digit",
+								})
+							: new Date().toLocaleTimeString(),
+						senderName: undefined,
+						attachment: attachment_payload.attachment_url
+							? {
+									url: attachment_payload.attachment_url,
+									type:
+										(attachment_payload.attachment_type as
+											| "image"
+											| "audio"
+											| "video"
+											| "file") || "file",
+									name: attachment_payload.attachment_name,
+									size: attachment_payload.attachment_size,
+								}
+							: undefined,
+					};
+
+					// Add agent response message
+					const agentMessage: ExtendedMessage = {
+						id: String(agentResponse.agentMessage.id),
+						content: agentResponse.agentMessage.content || "",
+						sender: "other",
+						timestamp: agentResponse.agentMessage.created_at
+							? new Date(
+									agentResponse.agentMessage.created_at,
+								).toLocaleTimeString("es-ES", {
+									hour: "2-digit",
+									minute: "2-digit",
+								})
+							: new Date().toLocaleTimeString(),
+						senderName: selectedAgent.name,
+					};
+
+					setMessages((prev) => [
+						...prev.filter((m) => m.id !== tempId),
+						userMessage,
+						agentMessage,
+					]);
+
+					// Update hook's messages map
+					const currentHookMsgs = messagesMap[chat.id] ?? [];
+					setMessagesForConversation(chat.id, [
+						...currentHookMsgs,
+						agentResponse.userMessage as BackendMessage,
+						agentResponse.agentMessage as BackendMessage,
+					]);
+
+					// Mark as read
+					try {
+						await markAsRead(chat.id, String(agentResponse.agentMessage.id));
+					} catch (err) {
+						console.error(err);
+					}
+				} else {
+					// Agent failed, remove optimistic message
+					setMessages((prev) => prev.filter((m) => m.id !== tempId));
+					toast({
+						title: "Error",
+						description: "No se pudo conectar con el agente. Intenta de nuevo.",
+					});
+					setAnErrorOcurred(true);
+				}
+			} else {
+				// Regular message sending (existing logic)
+				const payload: any = {
+					content: newMessage || null,
+					...attachment_payload,
+					reply_to: replyingTo?.id ?? null,
+				};
+
+				const sent = await sendMessage(chat.id, payload);
+				if (sent) {
+					const normalizedBackend: ExtendedMessage = {
+						id: String((sent as any).id),
+						content: sent.content ?? "",
+						sender: "me",
+						timestamp: sent.created_at
+							? new Date(sent.created_at).toLocaleTimeString("es-ES", {
+									hour: "2-digit",
+									minute: "2-digit",
+								})
+							: new Date().toLocaleTimeString(),
+						senderName: (sent as any).sender_name ?? undefined,
+						attachment: (sent as any).attachment_url
+							? {
+									url: (sent as any).attachment_url,
+									type:
+										(sent as any).attachment_type ??
+										attachment_payload.attachment_type ??
+										"file",
+									name:
+										(sent as any).attachment_name ??
+										attachment_payload.attachment_name,
+									size:
+										(sent as any).attachment_size ??
+										attachment_payload.attachment_size,
+								}
+							: undefined,
+						replyTo: sent.reply_to
+							? {
+									id: String(sent.reply_to),
+									content: (sent as any).reply_preview ?? "",
+									senderName: undefined,
+								}
+							: undefined,
+					};
+
+					setMessages((prev) =>
+						prev.map((m) => (m.id === tempId ? normalizedBackend : m)),
+					);
+
+					const currentHookMsgs = messagesMap[chat.id] ?? [];
+					setMessagesForConversation(chat.id, [
+						...currentHookMsgs,
+						sent as BackendMessage,
+					]);
+
+					try {
+						await markAsRead(chat.id, String(sent.id));
+					} catch (err) {
+						console.error(err);
+					}
+				}
+			}
+		} catch (err) {
+			console.error("Error sending message:", err);
+			setMessages((prev) => prev.filter((m) => m.id !== tempId));
+			toast({
+				title: "Error",
+				description: "No se pudo enviar el mensaje. Intenta de nuevo."
+			});
+			setAnErrorOcurred(true);
+		} finally {
+			setSending(false);
+			setWaitingForAgent(false);
+			setNewMessage("");
+			setAttachment(null);
+			setAttachmentPreview(null);
+			setReplyingTo(null);
+			if (fileInputRef.current) {
+				if (!anErrorOcurred) {
+					fileInputRef.current.value = "";
+				}
+			}
+		}
+	};
+
+	const handleKeyPress = (e: React.KeyboardEvent) => {
+		if (e.key === "Enter" && !e.shiftKey) {
+			e.preventDefault();
+			void handleSendMessage();
+		}
+	};
+
+	const handleReply = useCallback((message: ExtendedMessage) => {
+		setReplyingTo(message);
+	}, []);
+
+	const handleEdit = useCallback((message: ExtendedMessage) => {
+		setEditingMessageId(message.id);
+		setEditingContent(message.content);
+	}, []);
+
+	const handleDelete = useCallback((messageId: string) => {
+		// no backend delete implemented in endpoints — do local remove for now
+		setMessages((prev) => prev.filter((m) => m.id !== messageId));
+		// note: if you implement backend delete, call it here and refresh hook messages
+	}, []);
+
+	const handleCopy = useCallback((content: string) => {
+		navigator.clipboard.writeText(content);
+	}, []);
+
+	const handleSaveEdit = useCallback(
+		(messageId: string) => {
+			setMessages((prev) =>
+				prev.map((m) =>
+					m.id === messageId ? { ...m, content: editingContent } : m,
+				),
+			);
+			setEditingMessageId(null);
+			setEditingContent("");
+			// note: no backend edit endpoint implemented; if you add it, call it here and refresh hook
+		},
+		[editingContent],
+	);
+
+	const handleCancelEdit = useCallback(() => {
+		setEditingMessageId(null);
+		setEditingContent("");
+	}, []);
+
+	const removeAttachment = () => {
+		setAttachment(null);
+		setAttachmentPreview(null);
+		if (fileInputRef.current) {
+			fileInputRef.current.value = "";
+		}
+	};
+
+	const handleSetEditingContent = useCallback((content: string) => {
+		setEditingContent(content);
+	}, []);
+
+	return (
+		<div className="h-full flex flex-col">
+			{/* Messages */}
+			<ScrollArea className="flex-1 p-4" ref={scrollRef}>
+				<div className="space-y-4 max-w-4xl mx-auto">
+					{messages.map((message) => (
+						<ChatMessage
+							key={message.id}
+							message={message}
+							isHovered={hoveredMessageId === message.id}
+							isEditing={editingMessageId === message.id}
+							editingContent={editingContent}
+							onHover={setHoveredMessageId}
+							onReply={handleReply}
+							onEdit={handleEdit}
+							onDelete={handleDelete}
+							onCopy={handleCopy}
+							onSaveEdit={handleSaveEdit}
+							onCancelEdit={handleCancelEdit}
+							onEditingContentChange={handleSetEditingContent}
+						/>
+					))}
+
+					{/* Loading message for agent */}
+					{waitingForAgent && selectedAgent && (
+						<div className="flex gap-3">
+							<div className="w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center text-primary font-semibold text-sm flex-shrink-0">
+								<Bot className="w-4 h-4" />
+							</div>
+							<div className="flex flex-col items-start max-w-[70%]">
+								<span className="text-xs text-muted-foreground mb-1 px-1">
+									{selectedAgent.name}
+								</span>
+								<div className="bg-muted text-foreground rounded-2xl px-4 py-2">
+									<div className="flex items-center gap-2">
+										<div className="flex space-x-1">
+											<div
+												className="w-2 h-2 bg-muted-foreground rounded-full animate-bounce"
+												style={{ animationDelay: "0ms" }}
+											></div>
+											<div
+												className="w-2 h-2 bg-muted-foreground rounded-full animate-bounce"
+												style={{ animationDelay: "150ms" }}
+											></div>
+											<div
+												className="w-2 h-2 bg-muted-foreground rounded-full animate-bounce"
+												style={{ animationDelay: "300ms" }}
+											></div>
+										</div>
+										<span className="text-sm text-muted-foreground">
+											Escribiendo...
+										</span>
+									</div>
+								</div>
+							</div>
+						</div>
+					)}
+				</div>
+			</ScrollArea>
+
+			{/* Input */}
+			<div className="border-t border-border p-4 bg-card">
+				<div className="max-w-4xl mx-auto">
+					{selectedAgent && (
+						<div className="mb-2 p-2 bg-blue-50 dark:bg-blue-950/20 rounded-lg flex items-center justify-between">
+							<div className="flex items-center gap-2">
+								<div className="w-6 h-6 rounded-full bg-blue-100 dark:bg-blue-900 flex items-center justify-center">
+									<Bot className="h-3 w-3 text-blue-600" />
+								</div>
+								<div className="flex-1 min-w-0">
+									<p className="text-xs font-medium text-blue-900 dark:text-blue-100">
+										Agente activo: {selectedAgent.name}
+									</p>
+									<p className="text-xs text-blue-700 dark:text-blue-300">
+										Soporte: {selectedAgent.support.join(", ")}
+									</p>
+								</div>
+							</div>
+						</div>
+					)}
+
+					{replyingTo && (
+						<div className="mb-2 p-2 bg-muted rounded-lg flex items-center justify-between">
+							<div className="flex-1 min-w-0">
+								<p className="text-xs font-medium text-foreground">
+									Respondiendo a {replyingTo.senderName || "Usuario"}
+								</p>
+								<p className="text-xs text-muted-foreground truncate">
+									{replyingTo.content}
+								</p>
+							</div>
+							<Button
+								variant="ghost"
+								size="icon"
+								className="h-6 w-6"
+								onClick={() => setReplyingTo(null)}
+							>
+								<X className="h-4 w-4" />
+							</Button>
+						</div>
+					)}
+
+					{attachment && (
+						<div className="mb-2 p-2 bg-muted rounded-lg flex items-center gap-2">
+							{attachmentPreview ? (
+								<img
+									src={attachmentPreview || "/placeholder.svg"}
+									alt="Preview"
+									className="h-16 w-16 object-cover rounded"
+								/>
+							) : (
+								<div className="h-16 w-16 bg-background rounded flex items-center justify-center">
+									{attachment.type.startsWith("audio/") && (
+										<Mic className="h-6 w-6" />
+									)}
+									{attachment.type.startsWith("video/") && (
+										<Video className="h-6 w-6" />
+									)}
+									{!attachment.type.startsWith("audio/") &&
+										!attachment.type.startsWith("video/") && (
+											<File className="h-6 w-6" />
+										)}
+								</div>
+							)}
+							<div className="flex-1 min-w-0">
+								<p className="text-sm font-medium truncate">
+									{attachment.name}
+								</p>
+								<p className="text-xs text-muted-foreground">
+									{formatFileSize(attachment.size)}
+								</p>
+							</div>
+							<Button
+								variant="ghost"
+								size="icon"
+								className="h-8 w-8"
+								onClick={removeAttachment}
+							>
+								<X className="h-4 w-4" />
+							</Button>
+						</div>
+					)}
+
+					<div className="flex items-end gap-2">
+						<input
+							ref={fileInputRef}
+							type="file"
+							className="hidden"
+							onChange={handleFileSelect}
+							accept="image/*,audio/*,video/*,.pdf,.doc,.docx,.txt"
+						/>
+						<Button
+							variant="ghost"
+							size="icon"
+							className="flex-shrink-0"
+							onClick={() => fileInputRef.current?.click()}
+						>
+							<Paperclip className="h-5 w-5" />
+						</Button>
+						<div className="flex-1 relative">
+							<Textarea
+								placeholder="Escribe un mensaje..."
+								value={newMessage}
+								onChange={(e) => setNewMessage(e.target.value)}
+								onKeyPress={handleKeyPress}
+								className="pr-10 min-h-11 resize-none font-sans text-base border-none no-scrollbar"
+							/>
+							<Button
+								variant="ghost"
+								size="icon"
+								className="absolute right-1 top-1/2 -translate-y-1/2"
+							>
+								<Smile className="h-5 w-5" />
+							</Button>
+						</div>
+						<Button
+							onClick={() => void handleSendMessage()}
+							size="icon"
+							className="flex-shrink-0"
+							disabled={(!newMessage.trim() && !attachment) || sending}
+						>
+							<Send className="h-5 w-5" />
+						</Button>
+					</div>
+				</div>
+			</div>
+
+			<ChatSettings open={showSettings} onOpenChange={onShowSettingsChange} />
+		</div>
+	);
+}

--- a/client/react-frontend/src/chat/components/agents-chat-interface.tsx
+++ b/client/react-frontend/src/chat/components/agents-chat-interface.tsx
@@ -87,11 +87,6 @@ export function AgentsChatInterface() {
 							<Button className="w-full" onClick={() => void handleCreateAgentConversation()}>
 								Nueva conversación
 							</Button>
-							{selectedChat && (
-								<Button variant="secondary" className="w-full" onClick={() => setShowAgentsList(true)}>
-									Seleccionar agente para esta conversación
-								</Button>
-							)}
 						</div>
 					</div>
 					<div className="flex-1 overflow-y-auto p-2">
@@ -130,7 +125,21 @@ export function AgentsChatInterface() {
 							<h2 className="text-sm sm:text-base font-medium text-foreground truncate">
 								{selectedChat?.title || "Módulo de agentes"}
 							</h2>
-							<p className="text-xs text-muted-foreground truncate">{selectedAgent?.name || "Sin agente seleccionado"}</p>
+							<div className="flex items-center gap-2">
+								<p className="text-xs text-muted-foreground truncate">
+									{selectedAgent?.name || "Sin agente seleccionado"}
+								</p>
+								{selectedChat && (
+									<Button
+										variant="outline"
+										size="sm"
+										className="h-6 px-2 text-[11px]"
+										onClick={() => setShowAgentsList(true)}
+									>
+										{selectedAgent ? "Cambiar" : "Seleccionar"}
+									</Button>
+								)}
+							</div>
 						</div>
 					</div>
 					<div className="flex items-center gap-2">

--- a/client/react-frontend/src/chat/components/agents-chat-interface.tsx
+++ b/client/react-frontend/src/chat/components/agents-chat-interface.tsx
@@ -1,10 +1,18 @@
 "use client";
 
-import { Bot, Menu, Plus, Settings, X } from "lucide-react";
+import { Bot, Menu, MessageSquarePlus, Plus, Settings, X } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
 import { getRandomEmoji } from "@/utils/util";
 import useCurrentUser from "@/hooks/connection/useCurrentUser";
 import type { Agent } from "../../types/Agent";
@@ -25,6 +33,8 @@ export function AgentsChatInterface() {
 	const [showSettings, setShowSettings] = useState(false);
 	const [showAgentsList, setShowAgentsList] = useState(false);
 	const [showCreateAgent, setShowCreateAgent] = useState(false);
+	const [showCreateConversationModal, setShowCreateConversationModal] =
+		useState(false);
 	const [newConversationName, setNewConversationName] = useState("");
 	const { conversations, createConversation, fetchConversations } = useChatContext();
 	const { user } = useCurrentUser();
@@ -50,6 +60,7 @@ export function AgentsChatInterface() {
 		if (conversation) {
 			setSelectedChat(conversation);
 			setNewConversationName("");
+			setShowCreateConversationModal(false);
 			await fetchConversations();
 		}
 	};
@@ -78,16 +89,13 @@ export function AgentsChatInterface() {
 							</Button>
 						</div>
 						<p className="text-xs text-muted-foreground">Sección dedicada a conversaciones con agentes externos.</p>
-						<div className="space-y-2">
-							<Input
-								placeholder="Nombre de la conversación"
-								value={newConversationName}
-								onChange={(e) => setNewConversationName(e.target.value)}
-							/>
-							<Button className="w-full" onClick={() => void handleCreateAgentConversation()}>
-								Nueva conversación
-							</Button>
-						</div>
+						<Button
+							className="w-full"
+							onClick={() => setShowCreateConversationModal(true)}
+						>
+							<MessageSquarePlus className="h-4 w-4 mr-2" />
+							Nueva conversación
+						</Button>
 					</div>
 					<div className="flex-1 overflow-y-auto p-2">
 						{agentConversations.map((chat) => (
@@ -104,8 +112,15 @@ export function AgentsChatInterface() {
 										: "hover:bg-sidebar-accent/60"
 								}`}
 							>
-								<div className="font-medium truncate">{chat.title || "Agente"}</div>
-								<div className="text-xs text-muted-foreground truncate">{chat.last_message?.content || "Sin mensajes"}</div>
+								<div className="flex items-start gap-2">
+									<div className="w-7 h-7 rounded-full bg-primary/10 flex items-center justify-center text-primary shrink-0 mt-0.5">
+										<Bot className="h-3.5 w-3.5" />
+									</div>
+									<div className="min-w-0">
+										<div className="font-medium truncate">{chat.title || "Agente"}</div>
+										<div className="text-xs text-muted-foreground truncate">{chat.last_message?.content || "Sin mensajes"}</div>
+									</div>
+								</div>
 							</button>
 						))}
 					</div>
@@ -199,6 +214,35 @@ export function AgentsChatInterface() {
 					setShowCreateAgent(false);
 				}}
 			/>
+
+			<Dialog
+				open={showCreateConversationModal}
+				onOpenChange={setShowCreateConversationModal}
+			>
+				<DialogContent className="sm:max-w-md">
+					<DialogHeader>
+						<DialogTitle>Nueva conversación con agentes</DialogTitle>
+						<DialogDescription>
+							Asigna un nombre para crear la conversación y luego selecciona el agente.
+						</DialogDescription>
+					</DialogHeader>
+					<div className="space-y-2">
+						<Input
+							placeholder="Ej. Soporte IA - Infraestructura"
+							value={newConversationName}
+							onChange={(e) => setNewConversationName(e.target.value)}
+						/>
+					</div>
+					<DialogFooter>
+						<Button variant="outline" onClick={() => setShowCreateConversationModal(false)}>
+							Cancelar
+						</Button>
+						<Button onClick={() => void handleCreateAgentConversation()}>
+							Crear conversación
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
 		</div>
 	);
 }

--- a/client/react-frontend/src/chat/components/agents-chat-interface.tsx
+++ b/client/react-frontend/src/chat/components/agents-chat-interface.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { Bot, Menu, Settings } from "lucide-react";
+import { Bot, Menu, Plus, Settings, X } from "lucide-react";
 import { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { getRandomEmoji } from "@/utils/util";
 import type { Agent } from "../../types/Agent";
@@ -9,15 +10,17 @@ import type { Conversation } from "../hooks/useChat";
 import { useChatContext } from "../hooks/useChatContext";
 import { AgentsChatConversation } from "./agents-chat-conversation";
 import { AgentsListModal } from "./agents-list-modal";
-import { ChatToolbar } from "./chat-toolbar";
+import { CreateAgentModal } from "./create-agent-modal";
 import { ThemeToggle } from "./theme-toggle";
 
 export function AgentsChatInterface() {
+	const navigate = useNavigate();
 	const [selectedChat, setSelectedChat] = useState<Conversation | undefined>();
 	const [selectedAgent, setSelectedAgent] = useState<Agent | null>(null);
-	const [sidebarOpen, setSidebarOpen] = useState(true);
+	const [sidebarOpen, setSidebarOpen] = useState(false);
 	const [showSettings, setShowSettings] = useState(false);
 	const [showAgentsList, setShowAgentsList] = useState(false);
+	const [showCreateAgent, setShowCreateAgent] = useState(false);
 	const { conversations } = useChatContext();
 
 	const agentConversations = useMemo(
@@ -26,28 +29,44 @@ export function AgentsChatInterface() {
 	);
 
 	return (
-		<div className="flex h-screen bg-background">
-			<div
-				className={`${sidebarOpen ? "w-80" : "w-0"} transition-[width] duration-300 border-r border-border overflow-hidden min-w-0 shrink-0`}
+		<div className="flex h-screen bg-background overflow-hidden">
+			{sidebarOpen && (
+				<button
+					type="button"
+					className="fixed inset-0 bg-black/40 z-20 lg:hidden"
+					onClick={() => setSidebarOpen(false)}
+				/>
+			)}
+
+			<aside
+				className={`fixed lg:static inset-y-0 left-0 z-30 w-80 max-w-[85vw] transform border-r border-border bg-sidebar transition-transform duration-200 ${
+					sidebarOpen ? "translate-x-0" : "-translate-x-full lg:translate-x-0"
+				}`}
 			>
-				<div className="h-full flex flex-col bg-sidebar">
+				<div className="h-full flex flex-col">
 					<div className="p-4 border-b border-sidebar-border space-y-3">
 						<div className="flex items-center justify-between">
 							<h2 className="font-semibold text-sidebar-foreground">Chat con agentes</h2>
-							<Button size="sm" onClick={() => setShowAgentsList(true)}>
-								Seleccionar agente
-							</Button>
+							<div className="flex gap-2">
+								<Button size="icon" variant="outline" onClick={() => setShowCreateAgent(true)} title="Crear agente">
+									<Plus className="h-4 w-4" />
+								</Button>
+								<Button size="sm" onClick={() => setShowAgentsList(true)}>
+									Seleccionar
+								</Button>
+							</div>
 						</div>
-						<p className="text-xs text-muted-foreground">
-							Conversaciones dedicadas a agentes externos.
-						</p>
+						<p className="text-xs text-muted-foreground">Sección dedicada a conversaciones con agentes externos.</p>
 					</div>
 					<div className="flex-1 overflow-y-auto p-2">
 						{agentConversations.map((chat) => (
 							<button
 								key={chat.id}
 								type="button"
-								onClick={() => setSelectedChat(chat)}
+								onClick={() => {
+									setSelectedChat(chat);
+									setSidebarOpen(false);
+								}}
 								className={`w-full text-left p-3 rounded-lg mb-1 transition-colors ${
 									selectedChat?.id === chat.id
 										? "bg-sidebar-accent"
@@ -55,45 +74,35 @@ export function AgentsChatInterface() {
 								}`}
 							>
 								<div className="font-medium truncate">{chat.title || "Agente"}</div>
-								<div className="text-xs text-muted-foreground truncate">
-									{chat.last_message?.content || "Sin mensajes"}
-								</div>
+								<div className="text-xs text-muted-foreground truncate">{chat.last_message?.content || "Sin mensajes"}</div>
 							</button>
 						))}
 					</div>
 				</div>
-			</div>
+			</aside>
 
-			<div className="flex-1 flex flex-col">
-				<div className="h-16 border-b border-border flex items-center justify-between px-4 bg-card">
-					<div className="flex items-center gap-3">
-						<Button
-							variant="ghost"
-							size="icon"
-							onClick={() => setSidebarOpen((prev) => !prev)}
-						>
-							<Menu className="h-5 w-5" />
+			<main className="flex-1 flex flex-col min-w-0">
+				<header className="h-16 border-b border-border flex items-center justify-between px-3 sm:px-4 bg-card">
+					<div className="flex items-center gap-2 sm:gap-3 min-w-0">
+						<Button variant="ghost" size="icon" onClick={() => setSidebarOpen((v) => !v)}>
+							{sidebarOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
 						</Button>
-						{selectedChat && (
-							<div className="flex items-center gap-3">
-								<div className="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center text-primary font-semibold">
-									{getRandomEmoji()}
-								</div>
-								<div>
-									<h2 className="font-semibold text-lg text-foreground">
-										{selectedChat.title || "Conversación con agente"}
-									</h2>
-									<p className="text-xs text-muted-foreground flex items-center gap-1">
-										<Bot className="h-3 w-3" />
-										{selectedAgent?.name || "Sin agente seleccionado"}
-									</p>
-								</div>
-							</div>
-						)}
+						<div className="w-9 h-9 rounded-full bg-primary/10 flex items-center justify-center text-primary font-semibold shrink-0">
+							{selectedChat ? getRandomEmoji() : <Bot className="h-4 w-4" />}
+						</div>
+						<div className="min-w-0">
+							<h2 className="font-semibold text-foreground truncate">
+								{selectedChat?.title || "Módulo de agentes"}
+							</h2>
+							<p className="text-xs text-muted-foreground truncate">{selectedAgent?.name || "Sin agente seleccionado"}</p>
+						</div>
 					</div>
 					<div className="flex items-center gap-2">
-						<Button variant="outline" size="sm" onClick={() => setShowAgentsList(true)}>
+						<Button variant="outline" size="sm" className="hidden sm:inline-flex" onClick={() => setShowAgentsList(true)}>
 							Cambiar agente
+						</Button>
+						<Button variant="outline" size="icon" onClick={() => setShowCreateAgent(true)} title="Crear agente">
+							<Plus className="h-4 w-4" />
 						</Button>
 						{selectedChat && (
 							<Button variant="ghost" size="icon" onClick={() => setShowSettings(true)}>
@@ -101,8 +110,11 @@ export function AgentsChatInterface() {
 							</Button>
 						)}
 						<ThemeToggle />
+						<Button variant="ghost" size="sm" onClick={() => navigate("/chat")}>
+							Chat interno
+						</Button>
 					</div>
-				</div>
+				</header>
 
 				<div className="flex-1 overflow-hidden">
 					{selectedChat ? (
@@ -113,19 +125,28 @@ export function AgentsChatInterface() {
 							selectedAgent={selectedAgent}
 						/>
 					) : (
-						<div className="h-full flex items-center justify-center text-muted-foreground">
-							Selecciona una conversación de agente para comenzar.
+						<div className="h-full flex items-center justify-center text-muted-foreground p-6 text-center">
+							<div>
+								<h3 className="text-lg font-semibold text-foreground mb-2">Selecciona una conversación de agente</h3>
+								<p className="text-sm">Puedes crear un agente nuevo o seleccionar uno existente para iniciar.</p>
+							</div>
 						</div>
 					)}
 				</div>
-			</div>
-
-			<ChatToolbar selectedChat={selectedChat} onGoHome={() => setSelectedChat(undefined)} />
+			</main>
 
 			<AgentsListModal
 				open={showAgentsList}
 				onOpenChange={setShowAgentsList}
 				onAgentSelect={(agent) => setSelectedAgent(agent)}
+			/>
+			<CreateAgentModal
+				open={showCreateAgent}
+				onOpenChange={setShowCreateAgent}
+				onAgentCreated={(agent) => {
+					setSelectedAgent(agent);
+					setShowCreateAgent(false);
+				}}
 			/>
 		</div>
 	);

--- a/client/react-frontend/src/chat/components/agents-chat-interface.tsx
+++ b/client/react-frontend/src/chat/components/agents-chat-interface.tsx
@@ -44,9 +44,9 @@ export function AgentsChatInterface() {
 				}`}
 			>
 				<div className="h-full flex flex-col">
-					<div className="p-4 border-b border-sidebar-border space-y-3">
+					<div className="p-3 border-b border-sidebar-border space-y-2.5">
 						<div className="flex items-center justify-between">
-							<h2 className="font-semibold text-sidebar-foreground">Chat con agentes</h2>
+							<h2 className="text-sm font-semibold text-sidebar-foreground">Chat con agentes</h2>
 							<div className="flex gap-2">
 								<Button size="icon" variant="outline" onClick={() => setShowCreateAgent(true)} title="Crear agente">
 									<Plus className="h-4 w-4" />
@@ -82,16 +82,16 @@ export function AgentsChatInterface() {
 			</aside>
 
 			<main className="flex-1 flex flex-col min-w-0">
-				<header className="h-16 border-b border-border flex items-center justify-between px-3 sm:px-4 bg-card">
+				<header className="h-14 border-b border-border flex items-center justify-between px-3 sm:px-4 bg-card">
 					<div className="flex items-center gap-2 sm:gap-3 min-w-0">
 						<Button variant="ghost" size="icon" onClick={() => setSidebarOpen((v) => !v)}>
 							{sidebarOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
 						</Button>
-						<div className="w-9 h-9 rounded-full bg-primary/10 flex items-center justify-center text-primary font-semibold shrink-0">
+						<div className="w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center text-primary font-semibold shrink-0">
 							{selectedChat ? getRandomEmoji() : <Bot className="h-4 w-4" />}
 						</div>
 						<div className="min-w-0">
-							<h2 className="font-semibold text-foreground truncate">
+							<h2 className="text-sm sm:text-base font-medium text-foreground truncate">
 								{selectedChat?.title || "Módulo de agentes"}
 							</h2>
 							<p className="text-xs text-muted-foreground truncate">{selectedAgent?.name || "Sin agente seleccionado"}</p>
@@ -127,7 +127,7 @@ export function AgentsChatInterface() {
 					) : (
 						<div className="h-full flex items-center justify-center text-muted-foreground p-6 text-center">
 							<div>
-								<h3 className="text-lg font-semibold text-foreground mb-2">Selecciona una conversación de agente</h3>
+								<h3 className="text-base font-semibold text-foreground mb-2">Selecciona una conversación de agente</h3>
 								<p className="text-sm">Puedes crear un agente nuevo o seleccionar uno existente para iniciar.</p>
 							</div>
 						</div>

--- a/client/react-frontend/src/chat/components/agents-chat-interface.tsx
+++ b/client/react-frontend/src/chat/components/agents-chat-interface.tsx
@@ -153,6 +153,7 @@ export function AgentsChatInterface() {
 							showSettings={showSettings}
 							onShowSettingsChange={setShowSettings}
 							selectedAgent={selectedAgent}
+							onRequestAgentSelection={() => setShowAgentsList(true)}
 						/>
 					) : (
 						<div className="h-full flex items-center justify-center text-muted-foreground p-6 text-center">

--- a/client/react-frontend/src/chat/components/agents-chat-interface.tsx
+++ b/client/react-frontend/src/chat/components/agents-chat-interface.tsx
@@ -4,7 +4,9 @@ import { Bot, Menu, Plus, Settings, X } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { getRandomEmoji } from "@/utils/util";
+import useCurrentUser from "@/hooks/connection/useCurrentUser";
 import type { Agent } from "../../types/Agent";
 import type { Conversation } from "../hooks/useChat";
 import { useChatContext } from "../hooks/useChatContext";
@@ -16,17 +18,41 @@ import { ThemeToggle } from "./theme-toggle";
 export function AgentsChatInterface() {
 	const navigate = useNavigate();
 	const [selectedChat, setSelectedChat] = useState<Conversation | undefined>();
-	const [selectedAgent, setSelectedAgent] = useState<Agent | null>(null);
+	const [conversationAgents, setConversationAgents] = useState<
+		Record<string, Agent>
+	>({});
 	const [sidebarOpen, setSidebarOpen] = useState(false);
 	const [showSettings, setShowSettings] = useState(false);
 	const [showAgentsList, setShowAgentsList] = useState(false);
 	const [showCreateAgent, setShowCreateAgent] = useState(false);
-	const { conversations } = useChatContext();
+	const [newConversationName, setNewConversationName] = useState("");
+	const { conversations, createConversation, fetchConversations } = useChatContext();
+	const { user } = useCurrentUser();
 
 	const agentConversations = useMemo(
 		() => conversations.filter((conversation) => conversation.type === "bot"),
 		[conversations],
 	);
+
+	const selectedAgent = selectedChat ? conversationAgents[selectedChat.id] ?? null : null;
+
+	const handleCreateAgentConversation = async () => {
+		if (!user?.email) return;
+		const title = newConversationName.trim();
+		if (!title) return;
+
+		const conversation = await createConversation({
+			type: "bot",
+			title,
+			members: [user.email],
+		});
+
+		if (conversation) {
+			setSelectedChat(conversation);
+			setNewConversationName("");
+			await fetchConversations();
+		}
+	};
 
 	return (
 		<div className="flex h-screen bg-background overflow-hidden">
@@ -47,16 +73,26 @@ export function AgentsChatInterface() {
 					<div className="p-3 border-b border-sidebar-border space-y-2.5">
 						<div className="flex items-center justify-between">
 							<h2 className="text-sm font-semibold text-sidebar-foreground">Chat con agentes</h2>
-							<div className="flex gap-2">
-								<Button size="icon" variant="outline" onClick={() => setShowCreateAgent(true)} title="Crear agente">
-									<Plus className="h-4 w-4" />
-								</Button>
-								<Button size="sm" onClick={() => setShowAgentsList(true)}>
-									Seleccionar
-								</Button>
-							</div>
+							<Button size="icon" variant="outline" onClick={() => setShowCreateAgent(true)} title="Crear agente">
+								<Plus className="h-4 w-4" />
+							</Button>
 						</div>
 						<p className="text-xs text-muted-foreground">Sección dedicada a conversaciones con agentes externos.</p>
+						<div className="space-y-2">
+							<Input
+								placeholder="Nombre de la conversación"
+								value={newConversationName}
+								onChange={(e) => setNewConversationName(e.target.value)}
+							/>
+							<Button className="w-full" onClick={() => void handleCreateAgentConversation()}>
+								Nueva conversación
+							</Button>
+							{selectedChat && (
+								<Button variant="secondary" className="w-full" onClick={() => setShowAgentsList(true)}>
+									Seleccionar agente para esta conversación
+								</Button>
+							)}
+						</div>
 					</div>
 					<div className="flex-1 overflow-y-auto p-2">
 						{agentConversations.map((chat) => (
@@ -98,12 +134,6 @@ export function AgentsChatInterface() {
 						</div>
 					</div>
 					<div className="flex items-center gap-2">
-						<Button variant="outline" size="sm" className="hidden sm:inline-flex" onClick={() => setShowAgentsList(true)}>
-							Cambiar agente
-						</Button>
-						<Button variant="outline" size="icon" onClick={() => setShowCreateAgent(true)} title="Crear agente">
-							<Plus className="h-4 w-4" />
-						</Button>
 						{selectedChat && (
 							<Button variant="ghost" size="icon" onClick={() => setShowSettings(true)}>
 								<Settings className="h-5 w-5" />
@@ -138,13 +168,24 @@ export function AgentsChatInterface() {
 			<AgentsListModal
 				open={showAgentsList}
 				onOpenChange={setShowAgentsList}
-				onAgentSelect={(agent) => setSelectedAgent(agent)}
+				onAgentSelect={(agent) => {
+					if (!selectedChat) return;
+					setConversationAgents((prev) => ({
+						...prev,
+						[selectedChat.id]: agent,
+					}));
+				}}
 			/>
 			<CreateAgentModal
 				open={showCreateAgent}
 				onOpenChange={setShowCreateAgent}
 				onAgentCreated={(agent) => {
-					setSelectedAgent(agent);
+					if (selectedChat) {
+						setConversationAgents((prev) => ({
+							...prev,
+							[selectedChat.id]: agent,
+						}));
+					}
 					setShowCreateAgent(false);
 				}}
 			/>

--- a/client/react-frontend/src/chat/components/agents-chat-interface.tsx
+++ b/client/react-frontend/src/chat/components/agents-chat-interface.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { Bot, Menu, Settings } from "lucide-react";
+import { useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { getRandomEmoji } from "@/utils/util";
+import type { Agent } from "../../types/Agent";
+import type { Conversation } from "../hooks/useChat";
+import { useChatContext } from "../hooks/useChatContext";
+import { AgentsChatConversation } from "./agents-chat-conversation";
+import { AgentsListModal } from "./agents-list-modal";
+import { ChatToolbar } from "./chat-toolbar";
+import { ThemeToggle } from "./theme-toggle";
+
+export function AgentsChatInterface() {
+	const [selectedChat, setSelectedChat] = useState<Conversation | undefined>();
+	const [selectedAgent, setSelectedAgent] = useState<Agent | null>(null);
+	const [sidebarOpen, setSidebarOpen] = useState(true);
+	const [showSettings, setShowSettings] = useState(false);
+	const [showAgentsList, setShowAgentsList] = useState(false);
+	const { conversations } = useChatContext();
+
+	const agentConversations = useMemo(
+		() => conversations.filter((conversation) => conversation.type === "bot"),
+		[conversations],
+	);
+
+	return (
+		<div className="flex h-screen bg-background">
+			<div
+				className={`${sidebarOpen ? "w-80" : "w-0"} transition-[width] duration-300 border-r border-border overflow-hidden min-w-0 shrink-0`}
+			>
+				<div className="h-full flex flex-col bg-sidebar">
+					<div className="p-4 border-b border-sidebar-border space-y-3">
+						<div className="flex items-center justify-between">
+							<h2 className="font-semibold text-sidebar-foreground">Chat con agentes</h2>
+							<Button size="sm" onClick={() => setShowAgentsList(true)}>
+								Seleccionar agente
+							</Button>
+						</div>
+						<p className="text-xs text-muted-foreground">
+							Conversaciones dedicadas a agentes externos.
+						</p>
+					</div>
+					<div className="flex-1 overflow-y-auto p-2">
+						{agentConversations.map((chat) => (
+							<button
+								key={chat.id}
+								type="button"
+								onClick={() => setSelectedChat(chat)}
+								className={`w-full text-left p-3 rounded-lg mb-1 transition-colors ${
+									selectedChat?.id === chat.id
+										? "bg-sidebar-accent"
+										: "hover:bg-sidebar-accent/60"
+								}`}
+							>
+								<div className="font-medium truncate">{chat.title || "Agente"}</div>
+								<div className="text-xs text-muted-foreground truncate">
+									{chat.last_message?.content || "Sin mensajes"}
+								</div>
+							</button>
+						))}
+					</div>
+				</div>
+			</div>
+
+			<div className="flex-1 flex flex-col">
+				<div className="h-16 border-b border-border flex items-center justify-between px-4 bg-card">
+					<div className="flex items-center gap-3">
+						<Button
+							variant="ghost"
+							size="icon"
+							onClick={() => setSidebarOpen((prev) => !prev)}
+						>
+							<Menu className="h-5 w-5" />
+						</Button>
+						{selectedChat && (
+							<div className="flex items-center gap-3">
+								<div className="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center text-primary font-semibold">
+									{getRandomEmoji()}
+								</div>
+								<div>
+									<h2 className="font-semibold text-lg text-foreground">
+										{selectedChat.title || "Conversación con agente"}
+									</h2>
+									<p className="text-xs text-muted-foreground flex items-center gap-1">
+										<Bot className="h-3 w-3" />
+										{selectedAgent?.name || "Sin agente seleccionado"}
+									</p>
+								</div>
+							</div>
+						)}
+					</div>
+					<div className="flex items-center gap-2">
+						<Button variant="outline" size="sm" onClick={() => setShowAgentsList(true)}>
+							Cambiar agente
+						</Button>
+						{selectedChat && (
+							<Button variant="ghost" size="icon" onClick={() => setShowSettings(true)}>
+								<Settings className="h-5 w-5" />
+							</Button>
+						)}
+						<ThemeToggle />
+					</div>
+				</div>
+
+				<div className="flex-1 overflow-hidden">
+					{selectedChat ? (
+						<AgentsChatConversation
+							chat={selectedChat}
+							showSettings={showSettings}
+							onShowSettingsChange={setShowSettings}
+							selectedAgent={selectedAgent}
+						/>
+					) : (
+						<div className="h-full flex items-center justify-center text-muted-foreground">
+							Selecciona una conversación de agente para comenzar.
+						</div>
+					)}
+				</div>
+			</div>
+
+			<ChatToolbar selectedChat={selectedChat} onGoHome={() => setSelectedChat(undefined)} />
+
+			<AgentsListModal
+				open={showAgentsList}
+				onOpenChange={setShowAgentsList}
+				onAgentSelect={(agent) => setSelectedAgent(agent)}
+			/>
+		</div>
+	);
+}

--- a/client/react-frontend/src/chat/components/agents-list-modal.tsx
+++ b/client/react-frontend/src/chat/components/agents-list-modal.tsx
@@ -2,7 +2,6 @@
 
 import { Bot, Loader2, Pause, Play, Trash2 } from "lucide-react";
 import { type FC, useState } from "react";
-import { IoChatboxOutline } from "react-icons/io5";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -22,19 +21,8 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@/components/ui/dialog";
-import {
-	Table,
-	TableBody,
-	TableCell,
-	TableHead,
-	TableHeader,
-	TableRow,
-} from "@/components/ui/table";
-import useCurrentUser from "@/hooks/connection/useCurrentUser";
 import type { Agent, AgentSupport } from "../../types/Agent";
 import { useAgents } from "../hooks/useAgents";
-import { useChat } from "../hooks/useChat";
-import { useToast } from "@/hooks/use-toast";
 
 interface AgentsListModalProps {
 	open: boolean;
@@ -50,27 +38,6 @@ export const AgentsListModal: FC<AgentsListModalProps> = ({
 	const { agents, loading, deleteAgent, updateAgent } = useAgents();
 	const [deleteAgentId, setDeleteAgentId] = useState<string | null>(null);
 	const [isDeleting, setIsDeleting] = useState(false);
-	const { createConversation } = useChat();
-	const { user } = useCurrentUser();
-	const { toast } = useToast();
-
-	// crear conversacion con agente
-	const handleCreateConversationWithAgent = async (agent: Agent) => {
-		const conversation = await createConversation({
-			type: "bot",
-			contactemail: user?.email || "",
-			members: [user?.email || ""],
-			title: agent.name,
-		});
-
-		if (conversation) {
-			toast({
-				title: "Conversación creada",
-				description: `Se ha creado una nueva conversación con el agente ${agent.name}.`,
-			});
-		}
-		onOpenChange(false);
-	};
 
 	const getSupportBadgeColor = (support: AgentSupport) => {
 		switch (support) {
@@ -123,153 +90,92 @@ export const AgentsListModal: FC<AgentsListModalProps> = ({
 	return (
 		<>
 			<Dialog open={open} onOpenChange={onOpenChange}>
-				<DialogContent className="sm:max-w-[800px] max-h-[80vh]">
+				<DialogContent className="sm:max-w-[900px] max-h-[80vh] overflow-y-auto">
 					<DialogHeader>
-						<DialogTitle>Gestionar Agentes</DialogTitle>
+						<DialogTitle>Seleccionar agente</DialogTitle>
 						<DialogDescription>
-							Administra tus agentes de IA. Puedes activar, desactivar, editar o
-							eliminar agentes.
+							Elige qué agente quieres usar en la conversación actual.
 						</DialogDescription>
 					</DialogHeader>
 
-					<div className="space-y-4">
-						{loading ? (
-							<div className="flex items-center justify-center py-8">
-								<Loader2 className="h-6 w-6 animate-spin" />
-								<span className="ml-2">Cargando agentes...</span>
-							</div>
-						) : agents.length === 0 ? (
-							<div className="text-center py-8">
-								<Bot className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
-								<h3 className="text-lg font-semibold mb-2">No hay agentes</h3>
-								<p className="text-muted-foreground">
-									Crea tu primer agente para comenzar a usar el sistema.
-								</p>
-							</div>
-						) : (
-							<div className="border rounded-lg">
-								<Table>
-									<TableHeader>
-										<TableRow>
-											<TableHead>Nombre</TableHead>
-											<TableHead>URL</TableHead>
-											<TableHead>Soporte</TableHead>
-											<TableHead>Estado</TableHead>
-											<TableHead>Acciones</TableHead>
-										</TableRow>
-									</TableHeader>
-									<TableBody>
-										{agents.map((agent) => (
-											<TableRow key={agent.id}>
-												<TableCell>
-													<div className="flex items-center space-x-2">
-														<Bot className="h-4 w-4 text-primary" />
-														<div>
-															<div className="font-medium">{agent.name}</div>
-															{agent.description && (
-																<div className="text-sm text-muted-foreground">
-																	{agent.description}
-																</div>
-															)}
-														</div>
-													</div>
-												</TableCell>
-												<TableCell>
-													<div className="max-w-[200px] truncate text-sm text-muted-foreground">
-														{agent.url}
-													</div>
-												</TableCell>
-												<TableCell>
-													<div className="flex flex-wrap gap-1">
-														{agent.support.map((support) => (
-															<Badge
-																key={support}
-																variant="secondary"
-																className={`text-xs ${getSupportBadgeColor(support)}`}
-															>
-																{getSupportIcon(support)} {support}
-															</Badge>
-														))}
-													</div>
-												</TableCell>
-												<TableCell>
-													<Badge
-														variant={agent.is_active ? "default" : "secondary"}
-														className={
-															agent.is_active
-																? "bg-green-100 text-green-800"
-																: ""
-														}
-													>
-														{agent.is_active ? "Activo" : "Inactivo"}
-													</Badge>
-												</TableCell>
-												<TableCell>
-													<div className="flex items-center space-x-1">
-														<Button
-															variant="ghost"
-															size="sm"
-															onClick={() => handleAgentSelect(agent)}
-															title="Usar agente"
-														>
-															<Play className="h-4 w-4" />
-														</Button>
-														<Button
-															variant="ghost"
-															size="sm"
-															onClick={() => handleToggleAgent(agent)}
-															title={agent.is_active ? "Desactivar" : "Activar"}
-														>
-															{agent.is_active ? (
-																<Pause className="h-4 w-4" />
-															) : (
-																<Play className="h-4 w-4" />
-															)}
-														</Button>
-														<Button
-															variant="ghost"
-															size="sm"
-															onClick={() =>
-																handleCreateConversationWithAgent(agent)
-															}
-															title="Nuevo chat"
-															className="text-red-600 hover:text-red-700"
-														>
-															<IoChatboxOutline className="h-4 w-4" />
-														</Button>
-														<Button
-															variant="ghost"
-															size="sm"
-															onClick={() => setDeleteAgentId(agent.id)}
-															title="Eliminar"
-															className="text-red-600 hover:text-red-700"
-														>
-															<Trash2 className="h-4 w-4" />
-														</Button>
-													</div>
-												</TableCell>
-											</TableRow>
+					{loading ? (
+						<div className="flex items-center justify-center py-8">
+							<Loader2 className="h-6 w-6 animate-spin" />
+							<span className="ml-2">Cargando agentes...</span>
+						</div>
+					) : agents.length === 0 ? (
+						<div className="text-center py-8">
+							<Bot className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
+							<h3 className="text-lg font-semibold mb-2">No hay agentes</h3>
+							<p className="text-muted-foreground">
+								Crea tu primer agente para comenzar a usar el sistema.
+							</p>
+						</div>
+					) : (
+						<div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+							{agents.map((agent) => (
+								<div key={agent.id} className="border rounded-lg p-4 space-y-3 bg-card">
+									<div className="flex items-start justify-between gap-3">
+										<div className="min-w-0">
+											<div className="flex items-center gap-2">
+												<Bot className="h-4 w-4 text-primary" />
+												<h4 className="font-semibold truncate">{agent.name}</h4>
+											</div>
+											{agent.description && (
+												<p className="text-sm text-muted-foreground mt-1 line-clamp-2">
+													{agent.description}
+												</p>
+											)}
+										</div>
+										<Badge variant={agent.is_active ? "default" : "secondary"}>
+											{agent.is_active ? "Activo" : "Inactivo"}
+										</Badge>
+									</div>
+
+									<p className="text-xs text-muted-foreground truncate">{agent.url}</p>
+
+									<div className="flex flex-wrap gap-1">
+										{agent.support.map((support) => (
+											<Badge key={support} variant="secondary" className={`text-xs ${getSupportBadgeColor(support)}`}>
+												{getSupportIcon(support)} {support}
+											</Badge>
 										))}
-									</TableBody>
-								</Table>
-							</div>
-						)}
-					</div>
+									</div>
+
+									<div className="flex items-center gap-2 pt-1">
+										<Button size="sm" onClick={() => handleAgentSelect(agent)}>
+											Usar en conversación
+										</Button>
+										<Button
+											variant="outline"
+											size="sm"
+											onClick={() => handleToggleAgent(agent)}
+										>
+											{agent.is_active ? <Pause className="h-4 w-4 mr-1" /> : <Play className="h-4 w-4 mr-1" />}
+											{agent.is_active ? "Desactivar" : "Activar"}
+										</Button>
+										<Button
+											variant="ghost"
+											size="sm"
+											onClick={() => setDeleteAgentId(agent.id)}
+											className="text-red-600 hover:text-red-700"
+										>
+											<Trash2 className="h-4 w-4" />
+										</Button>
+									</div>
+								</div>
+							))}
+						</div>
+					)}
 				</DialogContent>
 			</Dialog>
 
-			{/* Delete Confirmation Dialog */}
-			<AlertDialog
-				open={!!deleteAgentId}
-				onOpenChange={() => setDeleteAgentId(null)}
-			>
+			<AlertDialog open={!!deleteAgentId} onOpenChange={() => setDeleteAgentId(null)}>
 				<AlertDialogContent>
 					<AlertDialogHeader>
 						<AlertDialogTitle>¿Eliminar agente?</AlertDialogTitle>
 						<AlertDialogDescription>
-							Esta acción no se puede deshacer. El agente será eliminado
-							permanentemente y ya no estará disponible para usar en
-							conversaciones.
+							Esta acción no se puede deshacer. El agente será eliminado permanentemente.
 						</AlertDialogDescription>
 					</AlertDialogHeader>
 					<AlertDialogFooter>

--- a/client/react-frontend/src/chat/components/chat-interface.tsx
+++ b/client/react-frontend/src/chat/components/chat-interface.tsx
@@ -74,16 +74,16 @@ export function ChatInterface() {
 			</aside>
 
 			<main className="flex-1 flex flex-col min-w-0">
-				<header className="h-16 border-b border-border flex items-center justify-between px-3 sm:px-4 bg-card">
+				<header className="h-14 border-b border-border flex items-center justify-between px-3 sm:px-4 bg-card">
 					<div className="flex items-center gap-2 sm:gap-3 min-w-0">
 						<Button variant="ghost" size="icon" onClick={() => setSidebarOpen((v) => !v)}>
 							{sidebarOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
 						</Button>
-						<div className="w-9 h-9 rounded-full bg-primary/10 flex items-center justify-center text-primary font-semibold shrink-0">
+						<div className="w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center text-primary font-semibold shrink-0 text-sm">
 							{selectedChat ? getRandomEmoji() : "💬"}
 						</div>
 						<div className="min-w-0">
-							<h2 className="font-semibold text-foreground truncate">{headerTitle}</h2>
+							<h2 className="text-sm sm:text-base font-medium text-foreground truncate">{headerTitle}</h2>
 							<p className="text-xs text-muted-foreground truncate">Canal de colaboración interna</p>
 						</div>
 					</div>
@@ -115,7 +115,7 @@ export function ChatInterface() {
 					) : (
 						<div className="h-full flex items-center justify-center text-muted-foreground p-6 text-center">
 							<div>
-								<h3 className="text-lg font-semibold mb-2 text-foreground">Bienvenido a SYSGD-CHAT</h3>
+								<h3 className="text-base font-semibold mb-2 text-foreground">Bienvenido a SYSGD-CHAT</h3>
 								<p className="text-sm">Selecciona una conversación para comenzar.</p>
 							</div>
 						</div>

--- a/client/react-frontend/src/chat/components/chat-interface.tsx
+++ b/client/react-frontend/src/chat/components/chat-interface.tsx
@@ -4,7 +4,6 @@ import { Menu, Settings } from "lucide-react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { getRandomEmoji } from "@/utils/util";
-import type { Agent } from "../../types/Agent";
 import type { Conversation } from "../hooks/useChat";
 import { ChatConversation } from "./chat-conversation";
 import { ChatSidebar } from "./chat-sidebar";
@@ -39,7 +38,6 @@ export function ChatInterface() {
 	);
 	const [sidebarOpen, setSidebarOpen] = useState(true);
 	const [showSettings, setShowSettings] = useState(false);
-	const [selectedAgent, setSelectedAgent] = useState<Agent | null>(null);
 
 	return (
 		<div className="flex h-screen bg-background">
@@ -50,7 +48,6 @@ export function ChatInterface() {
 				<ChatSidebar
 					selectedChat={selectedChat ?? undefined}
 					onSelectChat={setSelectedChat}
-					onAgentSelect={setSelectedAgent}
 				/>
 			</div>
 
@@ -87,7 +84,7 @@ export function ChatInterface() {
 												: "Me"}
 									</h2>
 									<p className="text-xs text-muted-foreground">
-										{selectedChat.type === "bot" ? "Agente" : "Usuario"}
+										Chat interno de equipo
 										{/* {selectedChat.online && " • En línea"} */}
 									</p>
 								</div>
@@ -115,7 +112,6 @@ export function ChatInterface() {
 							chat={selectedChat}
 							showSettings={showSettings}
 							onShowSettingsChange={setShowSettings}
-							selectedAgent={selectedAgent}
 						/>
 					) : (
 						<div className="h-full flex items-center justify-center text-muted-foreground">
@@ -152,7 +148,6 @@ export function ChatInterface() {
 			<ChatToolbar
 				selectedChat={selectedChat}
 				onGoHome={() => setSelectedChat(undefined)}
-				onAgentSelect={setSelectedAgent}
 			/>
 		</div>
 	);

--- a/client/react-frontend/src/chat/components/chat-interface.tsx
+++ b/client/react-frontend/src/chat/components/chat-interface.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { Menu, Settings } from "lucide-react";
-import { useState } from "react";
+import { Menu, MessageSquare, Settings, X } from "lucide-react";
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { getRandomEmoji } from "@/utils/util";
 import type { Conversation } from "../hooks/useChat";
@@ -33,79 +34,77 @@ export interface Message {
 }
 
 export function ChatInterface() {
-	const [selectedChat, setSelectedChat] = useState<Conversation | undefined>(
-		undefined,
-	);
-	const [sidebarOpen, setSidebarOpen] = useState(true);
+	const navigate = useNavigate();
+	const [selectedChat, setSelectedChat] = useState<Conversation | undefined>();
+	const [sidebarOpen, setSidebarOpen] = useState(false);
 	const [showSettings, setShowSettings] = useState(false);
 
+	const headerTitle = useMemo(() => {
+		if (!selectedChat) return "Chat interno";
+		return (
+			selectedChat.title ||
+			(selectedChat.members && selectedChat.members.length === 2
+				? selectedChat.members[1].name
+				: "Conversación")
+		);
+	}, [selectedChat]);
+
 	return (
-		<div className="flex h-screen bg-background">
-			{/* Sidebar */}
-			<div
-				className={`${sidebarOpen ? "w-80" : "w-0"} transition-[width] duration-300 border-r border-border overflow-hidden min-w-0 shrink-0`}
+		<div className="flex h-screen bg-background overflow-hidden">
+			{sidebarOpen && (
+				<button
+					type="button"
+					className="fixed inset-0 bg-black/40 z-20 lg:hidden"
+					onClick={() => setSidebarOpen(false)}
+				/>
+			)}
+
+			<aside
+				className={`fixed lg:static inset-y-0 left-0 z-30 w-80 max-w-[85vw] transform border-r border-border bg-sidebar transition-transform duration-200 ${
+					sidebarOpen ? "translate-x-0" : "-translate-x-full lg:translate-x-0"
+				}`}
 			>
 				<ChatSidebar
-					selectedChat={selectedChat ?? undefined}
-					onSelectChat={setSelectedChat}
+					selectedChat={selectedChat}
+					onSelectChat={(chat) => {
+						setSelectedChat(chat);
+						setSidebarOpen(false);
+					}}
 				/>
-			</div>
+			</aside>
 
-			{/* Main Chat Area */}
-			<div className="flex-1 flex flex-col">
-				{/* Header */}
-				<div className="h-16 border-b border-border flex items-center justify-between px-4 bg-card">
-					<div className="flex items-center gap-3">
+			<main className="flex-1 flex flex-col min-w-0">
+				<header className="h-16 border-b border-border flex items-center justify-between px-3 sm:px-4 bg-card">
+					<div className="flex items-center gap-2 sm:gap-3 min-w-0">
+						<Button variant="ghost" size="icon" onClick={() => setSidebarOpen((v) => !v)}>
+							{sidebarOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+						</Button>
+						<div className="w-9 h-9 rounded-full bg-primary/10 flex items-center justify-center text-primary font-semibold shrink-0">
+							{selectedChat ? getRandomEmoji() : "💬"}
+						</div>
+						<div className="min-w-0">
+							<h2 className="font-semibold text-foreground truncate">{headerTitle}</h2>
+							<p className="text-xs text-muted-foreground truncate">Canal de colaboración interna</p>
+						</div>
+					</div>
+					<div className="flex items-center gap-1 sm:gap-2">
 						<Button
 							variant="ghost"
 							size="icon"
-							onClick={() => setSidebarOpen(!sidebarOpen)}
+							onClick={() => navigate("/chat/agents")}
+							title="Ir al chat con agentes"
 						>
-							<Menu className="h-5 w-5" />
+							<MessageSquare className="h-5 w-5" />
 						</Button>
 						{selectedChat && (
-							<div className="flex items-center gap-3">
-								<div className="relative">
-									<div className="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center text-primary font-semibold">
-										{/* {selectedChat.avatar || selectedChat.name.charAt(0)} */}{" "}
-										{getRandomEmoji()}
-									</div>
-									{/* {selectedChat.online && (
-										<div className="absolute bottom-0 right-0 w-3 h-3 bg-green-500 rounded-full border-2 border-card" />
-									)} */}
-								</div>
-								<div>
-									<h2 className="font-semibold text-lg text-foreground">
-										{selectedChat.title
-											? selectedChat.title
-											: selectedChat.members &&
-													selectedChat.members.length === 2
-												? selectedChat.members[1].name
-												: "Me"}
-									</h2>
-									<p className="text-xs text-muted-foreground">
-										Chat interno de equipo
-										{/* {selectedChat.online && " • En línea"} */}
-									</p>
-								</div>
-							</div>
-						)}
-					</div>
-					<div className="flex items-center gap-2">
-						{selectedChat && (
-							<Button
-								variant="ghost"
-								size="icon"
-								onClick={() => setShowSettings(true)}
-							>
+							<Button variant="ghost" size="icon" onClick={() => setShowSettings(true)}>
 								<Settings className="h-5 w-5" />
 							</Button>
 						)}
 						<ThemeToggle />
 					</div>
-				</div>
+				</header>
 
-				{/* Conversation */}
 				<div className="flex-1 overflow-hidden">
 					{selectedChat ? (
 						<ChatConversation
@@ -114,41 +113,17 @@ export function ChatInterface() {
 							onShowSettingsChange={setShowSettings}
 						/>
 					) : (
-						<div className="h-full flex items-center justify-center text-muted-foreground">
-							<div className="text-center">
-								<div className="w-24 h-24 mx-auto mb-4 rounded-full bg-primary/10 flex items-center justify-center">
-									{/** biome-ignore lint/a11y/noSvgWithoutTitle: <explanation> */}
-									<svg
-										className="w-12 h-12 text-primary"
-										fill="none"
-										stroke="currentColor"
-										viewBox="0 0 24 24"
-									>
-										<path
-											strokeLinecap="round"
-											strokeLinejoin="round"
-											strokeWidth={2}
-											d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
-										/>
-									</svg>
-								</div>
-								<h3 className="text-lg font-semibold mb-2 text-foreground">
-									Bienvenido a SYSGD-CHAT
-								</h3>
-								<p className="text-sm">
-									Selecciona una conversación para comenzar
-								</p>
+						<div className="h-full flex items-center justify-center text-muted-foreground p-6 text-center">
+							<div>
+								<h3 className="text-lg font-semibold mb-2 text-foreground">Bienvenido a SYSGD-CHAT</h3>
+								<p className="text-sm">Selecciona una conversación para comenzar.</p>
 							</div>
 						</div>
 					)}
 				</div>
-			</div>
+			</main>
 
-			{/* Toolbar */}
-			<ChatToolbar
-				selectedChat={selectedChat}
-				onGoHome={() => setSelectedChat(undefined)}
-			/>
+			<ChatToolbar selectedChat={selectedChat} onGoHome={() => setSelectedChat(undefined)} />
 		</div>
 	);
 }

--- a/client/react-frontend/src/chat/components/chat-sidebar.tsx
+++ b/client/react-frontend/src/chat/components/chat-sidebar.tsx
@@ -31,7 +31,7 @@ export function ChatSidebar({ selectedChat, onSelectChat }: ChatSidebarProps) {
 
 	return (
 		<div className="h-full flex flex-col bg-sidebar min-w-0">
-			<div className="p-4 border-b border-sidebar-border space-y-3">
+			<div className="p-3 border-b border-sidebar-border space-y-2.5">
 				<div className="flex items-center justify-between">
 					<Button
 						variant="ghost"
@@ -41,9 +41,9 @@ export function ChatSidebar({ selectedChat, onSelectChat }: ChatSidebarProps) {
 					>
 						<Home className="w-4 h-4 mr-1" /> Inicio
 					</Button>
-					<div className="flex gap-2 items-center">
+					<div className="flex gap-1.5 items-center">
 						<IoChatboxOutline className="size-4" />
-						<h1 className="text-lg font-bold text-sidebar-foreground">SYSGD-CHAT</h1>
+						<h1 className="text-sm font-semibold text-sidebar-foreground">SYSGD-CHAT</h1>
 					</div>
 				</div>
 

--- a/client/react-frontend/src/chat/components/chat-sidebar.tsx
+++ b/client/react-frontend/src/chat/components/chat-sidebar.tsx
@@ -1,14 +1,12 @@
-// biome-ignore assist/source/organizeImports: <explanation>
 import { type FC, useState } from "react";
-import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
-import { Search, Users, Home } from "lucide-react";
-import { type Conversation } from "../hooks/useChat";
-import { getEmojiFromName } from "@/utils/util";
-import { useNavigate } from "react-router-dom";
+import { Home, Search, Users } from "lucide-react";
 import { IoChatboxOutline } from "react-icons/io5";
+import { useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { getEmojiFromName } from "@/utils/util";
+import type { Conversation } from "../hooks/useChat";
 import { useChatContext } from "../hooks/useChatContext";
-
 
 interface ChatSidebarProps {
 	selectedChat?: Conversation;
@@ -19,51 +17,37 @@ export function ChatSidebar({ selectedChat, onSelectChat }: ChatSidebarProps) {
 	const navigate = useNavigate();
 	const [searchQuery, setSearchQuery] = useState("");
 	const [filter, setFilter] = useState<"all" | "private">("all");
-
 	const { conversations } = useChatContext();
 
 	const filteredChats = conversations.filter((chat) => {
-		if (!chat.members || chat.members.length === 0 || !chat.members[0].name)
-			return false;
-
-		const matchesSearch = chat.members?.[0].name
+		const chatName = chat.title || chat.members?.[0]?.name || "";
+		if (!chatName) return false;
+		const matchesSearch = chatName
 			.toLowerCase()
 			.includes(searchQuery.toLowerCase());
 		const matchesFilter = filter === "all" || chat.type === filter;
-		return matchesSearch && matchesFilter;
+		return matchesSearch && matchesFilter && chat.type !== "bot";
 	});
 
 	return (
 		<div className="h-full flex flex-col bg-sidebar min-w-0">
-			{/* Header */}
-			<div className="p-4 border-b border-sidebar-border">
-				<div className="flex items-center justify-between mb-4">
-					<div className="flex items-center gap-2">
-						<Button
-							variant="ghost"
-							size="sm"
-							onClick={() => {
-								navigate("/dashboard");
-							}}
-							className={
-								"flex items-center gap-2 text-blue-600 dark:text-blue-400"
-							}
-						>
-							<Home className="w-4 h-4" />
-							<span className="hidden sm:inline">Inicio</span>
-						</Button>
-					</div>
-					<div className="h-6 w-px bg-gray-300 dark:bg-gray-600 hidden sm:block" />
-					<div className="flex gap-2 items-center w-full ml-4">
+			<div className="p-4 border-b border-sidebar-border space-y-3">
+				<div className="flex items-center justify-between">
+					<Button
+						variant="ghost"
+						size="sm"
+						onClick={() => navigate("/dashboard")}
+						className="text-blue-600 dark:text-blue-400"
+					>
+						<Home className="w-4 h-4 mr-1" /> Inicio
+					</Button>
+					<div className="flex gap-2 items-center">
 						<IoChatboxOutline className="size-4" />
-						<h1 className="text-lg font-bold text-sidebar-foreground">
-							SYSGD-CHAT
-						</h1>
+						<h1 className="text-lg font-bold text-sidebar-foreground">SYSGD-CHAT</h1>
 					</div>
 				</div>
 
-				{/* Search */}
-				<div className="relative mb-3">
+				<div className="relative">
 					<Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
 					<Input
 						placeholder="Buscar conversaciones..."
@@ -73,13 +57,11 @@ export function ChatSidebar({ selectedChat, onSelectChat }: ChatSidebarProps) {
 					/>
 				</div>
 
-				{/* Filters */}
-				<div className="flex gap-2">
+				<div className="grid grid-cols-2 gap-2">
 					<Button
 						variant={filter === "all" ? "default" : "outline"}
 						size="sm"
 						onClick={() => setFilter("all")}
-						className="flex-1"
 					>
 						Todos
 					</Button>
@@ -87,35 +69,21 @@ export function ChatSidebar({ selectedChat, onSelectChat }: ChatSidebarProps) {
 						variant={filter === "private" ? "default" : "outline"}
 						size="sm"
 						onClick={() => setFilter("private")}
-						className="flex-1"
 					>
-						<Users className="h-4 w-4 mr-1" />
-						Usuarios
-					</Button>
-					<Button
-						variant="outline"
-						size="sm"
-						disabled
-						className="flex-1"
-						title="El chat con agentes ahora vive en un módulo independiente"
-					>
-						Agentes (módulo separado)
+						<Users className="h-4 w-4 mr-1" /> Directos
 					</Button>
 				</div>
 			</div>
 
-			{/* Chat List */}
-			<div className="flex-1 overflow-y-auto min-w-0 overflow-x-hidden">
-				<div className="p-2 w-full min-w-0">
-					{filteredChats.map((chat) => (
-						<ChatConversationItem
-							key={chat.id}
-							chat={chat}
-							onSelectChat={onSelectChat}
-							isSelected={selectedChat?.id === chat.id}
-						/>
-					))}
-				</div>
+			<div className="flex-1 overflow-y-auto p-2">
+				{filteredChats.map((chat) => (
+					<ChatConversationItem
+						key={chat.id}
+						chat={chat}
+						onSelectChat={onSelectChat}
+						isSelected={selectedChat?.id === chat.id}
+					/>
+				))}
 			</div>
 		</div>
 	);
@@ -125,50 +93,34 @@ const ChatConversationItem: FC<{
 	chat: Conversation;
 	onSelectChat: (chat: Conversation) => void;
 	isSelected: boolean;
-}> = ({ chat, onSelectChat, isSelected }) => {
-	return (
-		<button
-			type="button"
-			onClick={() => onSelectChat(chat)}
-			className={`
-    w-full min-w-0 flex p-3 rounded-lg mb-1 text-left transition-colors
-    ${isSelected ? "bg-sidebar-accent" : "hover:bg-sidebar-accent/50"}
-  `}
-		>
-			<div className="flex items-start gap-3 w-full min-w-0">
-				<div className="flex-shrink-0 min-w-0">
-					<div className="w-12 h-12 rounded-full bg-sidebar-primary/10 flex items-center justify-center">
-						{getEmojiFromName(
-							chat.title || chat.members?.[0]?.name || "Usuario",
-						)}
-					</div>
-				</div>
-
-				<div className="flex-1 flex flex-col min-w-0">
-					<div className="flex items-baseline justify-between gap-2 mb-1 min-w-0">
-						<h3 className="font-semibold text-sm truncate flex-1 min-w-0">
-							{chat.title ?? chat.members?.[0]?.name}
-						</h3>
-						<span className="text-xs whitespace-nowrap flex-shrink-0">
-							{chat.last_message?.created_at
-								? new Date(chat.last_message.created_at).toLocaleTimeString(
-										[],
-										{
-											hour: "2-digit",
-											minute: "2-digit",
-										},
-									)
-								: ""}
-						</span>
-					</div>
-
-					<div className="flex items-center gap-2 min-w-0">
-						<p className="text-sm truncate flex-1 min-w-0">
-							{chat.last_message?.content || "Sin mensajes aún"}
-						</p>
-					</div>
-				</div>
+}> = ({ chat, onSelectChat, isSelected }) => (
+	<button
+		type="button"
+		onClick={() => onSelectChat(chat)}
+		className={`w-full p-3 rounded-lg mb-1 text-left transition-colors ${
+			isSelected ? "bg-sidebar-accent" : "hover:bg-sidebar-accent/50"
+		}`}
+	>
+		<div className="flex items-start gap-3">
+			<div className="w-10 h-10 rounded-full bg-sidebar-primary/10 flex items-center justify-center text-sm">
+				{getEmojiFromName(chat.title || chat.members?.[0]?.name || "Usuario")}
 			</div>
-		</button>
-	);
-};
+			<div className="flex-1 min-w-0">
+				<div className="flex justify-between gap-2 mb-1">
+					<h3 className="font-semibold text-sm truncate">{chat.title ?? chat.members?.[0]?.name}</h3>
+					<span className="text-xs whitespace-nowrap">
+						{chat.last_message?.created_at
+							? new Date(chat.last_message.created_at).toLocaleTimeString([], {
+									hour: "2-digit",
+									minute: "2-digit",
+								})
+							: ""}
+					</span>
+				</div>
+				<p className="text-sm truncate text-muted-foreground">
+					{chat.last_message?.content || "Sin mensajes aún"}
+				</p>
+			</div>
+		</div>
+	</button>
+);

--- a/client/react-frontend/src/chat/components/chat-sidebar.tsx
+++ b/client/react-frontend/src/chat/components/chat-sidebar.tsx
@@ -2,34 +2,25 @@
 import { type FC, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Search, Users, Bot, Home } from "lucide-react";
-import { type Conversation, useChat } from "../hooks/useChat";
+import { Search, Users, Home } from "lucide-react";
+import { type Conversation } from "../hooks/useChat";
 import { getEmojiFromName } from "@/utils/util";
 import { useNavigate } from "react-router-dom";
 import { IoChatboxOutline } from "react-icons/io5";
-import { useAgents } from "../hooks/useAgents";
-import type { Agent } from "../../types/Agent";
+import { useChatContext } from "../hooks/useChatContext";
 
 
 interface ChatSidebarProps {
 	selectedChat?: Conversation;
 	onSelectChat: (chat: Conversation) => void;
-	onAgentSelect?: (agent: Agent) => void;
 }
 
 export function ChatSidebar({ selectedChat, onSelectChat }: ChatSidebarProps) {
 	const navigate = useNavigate();
 	const [searchQuery, setSearchQuery] = useState("");
-	const [filter, setFilter] = useState<
-		"all" | "user" | "agent" | "private" | "bot"
-	>("all");
+	const [filter, setFilter] = useState<"all" | "private">("all");
 
-	const { conversations } = useChat();
-	const { agents } = useAgents();
-
-	console.log(agents)
-
-	console.log("Conversations in Sidebar:", conversations);
+	const { conversations } = useChatContext();
 
 	const filteredChats = conversations.filter((chat) => {
 		if (!chat.members || chat.members.length === 0 || !chat.members[0].name)
@@ -102,13 +93,13 @@ export function ChatSidebar({ selectedChat, onSelectChat }: ChatSidebarProps) {
 						Usuarios
 					</Button>
 					<Button
-						variant={filter === "bot" ? "default" : "outline"}
+						variant="outline"
 						size="sm"
-						onClick={() => setFilter("bot")}
+						disabled
 						className="flex-1"
+						title="El chat con agentes ahora vive en un módulo independiente"
 					>
-						<Bot className="h-4 w-4 mr-1" />
-						Agentes
+						Agentes (módulo separado)
 					</Button>
 				</div>
 			</div>

--- a/client/react-frontend/src/chat/components/chat-toolbar.tsx
+++ b/client/react-frontend/src/chat/components/chat-toolbar.tsx
@@ -17,7 +17,7 @@ export const ChatToolbar: FC<ChatToolbarProps> = ({ onGoHome }) => {
 	return (
 		<>
 			<aside className="hidden xl:flex h-full w-64 border-l border-border bg-card p-4 flex-col">
-				<h3 className="font-semibold text-foreground mb-3">Acciones</h3>
+				<h3 className="text-sm font-medium text-foreground mb-3">Acciones</h3>
 				<div className="space-y-2">
 					<Button
 						variant="default"

--- a/client/react-frontend/src/chat/components/chat-toolbar.tsx
+++ b/client/react-frontend/src/chat/components/chat-toolbar.tsx
@@ -1,166 +1,48 @@
-import {
-	ChevronLeft,
-	ChevronRight,
-	HelpCircle,
-	Home,
-	MessageSquare,
-	Settings,
-} from "lucide-react";
+import { Home, MessageSquare, Plus } from "lucide-react";
 import { type FC, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import type { Conversation } from "../hooks/useChat";
 import { NewChatModal } from "./new-chat-modal";
-import { useNavigate } from "react-router-dom";
 
 interface ChatToolbarProps {
 	selectedChat?: Conversation;
 	onGoHome: () => void;
 }
 
-export const ChatToolbar: FC<ChatToolbarProps> = ({
-	selectedChat,
-	onGoHome,
-}) => {
+export const ChatToolbar: FC<ChatToolbarProps> = ({ onGoHome }) => {
 	const navigate = useNavigate();
-	const [isCollapsed, setIsCollapsed] = useState(false);
 	const [isNewChatModalOpen, setIsNewChatModalOpen] = useState(false);
-
-	const toolbarItems = [
-		{
-			id: "home",
-			icon: Home,
-			label: "Inicio",
-			onClick: onGoHome,
-			variant: "ghost" as const,
-		},
-		{
-			id: "agents-module",
-			icon: MessageSquare,
-			label: "Chat con Agentes",
-			onClick: () => navigate("/chat/agents"),
-			variant: "outline" as const,
-		},
-		{
-			id: "settings",
-			icon: Settings,
-			label: "Configuración",
-			onClick: () => console.log("Settings clicked"),
-			variant: "ghost" as const,
-		},
-		{
-			id: "help",
-			icon: HelpCircle,
-			label: "Ayuda",
-			onClick: () => console.log("Help clicked"),
-			variant: "ghost" as const,
-		},
-	];
 
 	return (
 		<>
-			<div
-				className={`h-full bg-card border-l justify-center border-border overflow-hidden transition-all duration-300 ${
-					isCollapsed ? "w-16" : "w-64"
-				}`}
-			>
-				{/* Header */}
-				<div className="p-4 border-b border-border">
-					<div className="flex items-center justify-between">
-						{!isCollapsed && (
-							<h3 className="font-semibold text-foreground text-lg">
-								Herramientas
-							</h3>
-						)}
-						<div>
-							<Button
-								variant="ghost"
-								size="icon"
-								onClick={() => setIsCollapsed(!isCollapsed)}
-								className="h-8 w-8"
-							>
-								{isCollapsed ? (
-									<ChevronLeft className="h-4 w-4" />
-								) : (
-									<ChevronRight className="h-4 w-4" />
-								)}
-							</Button>
-						</div>
-					</div>
+			<aside className="hidden xl:flex h-full w-64 border-l border-border bg-card p-4 flex-col">
+				<h3 className="font-semibold text-foreground mb-3">Acciones</h3>
+				<div className="space-y-2">
+					<Button
+						variant="default"
+						className="w-full justify-start"
+						onClick={() => setIsNewChatModalOpen(true)}
+					>
+						<Plus className="h-4 w-4 mr-2" /> Nueva conversación
+					</Button>
+					<Button variant="outline" className="w-full justify-start" onClick={onGoHome}>
+						<Home className="h-4 w-4 mr-2" /> Inicio chat interno
+					</Button>
+					<Button
+						variant="outline"
+						className="w-full justify-start"
+						onClick={() => navigate("/chat/agents")}
+					>
+						<MessageSquare className="h-4 w-4 mr-2" /> Ir a chat con agentes
+					</Button>
 				</div>
-
-				{/* Toolbar Items */}
-				<div className="p-2 space-y-1">
-					{toolbarItems.map((item) => {
-						const Icon = item.icon;
-						return (
-							<Button
-								key={item.id}
-								variant={item.variant}
-								size={isCollapsed ? "icon" : "sm"}
-								onClick={item.onClick}
-								className={`w-full  ${
-									isCollapsed ? "justify-center h-10 w-10" : "justify-start h-10"
-								}`}
-								title={isCollapsed ? item.label : undefined}
-							>
-								<Icon className="h-4 w-4" />
-								{!isCollapsed && (
-									<span className="ml-2 text-sm">{item.label}</span>
-								)}
-							</Button>
-						);
-					})}
-				</div>
-
-				{/* Selected Chat Info */}
-				{selectedChat && !isCollapsed && (
-					<div className="p-4 border-t border-border">
-						<div className="text-xs text-muted-foreground mb-2">
-							Conversación actual:
-						</div>
-						<div className="flex items-center gap-2">
-							<div className="w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center text-primary font-semibold text-xs">
-								{selectedChat.title?.charAt(0) || "?"}
-							</div>
-							<div className="flex-1 min-w-0">
-								<div className="text-sm font-medium text-foreground truncate">
-									{selectedChat.title || "Sin nombre"}
-								</div>
-								<div className="text-xs text-muted-foreground">
-									Chat interno de equipo
-								</div>
-							</div>
-						</div>
-					</div>
-				)}
-
-				{/* Quick Actions */}
-				{!isCollapsed && (
-					<div className="p-4 border-t border-border">
-						<div className="text-xs text-muted-foreground mb-2">
-							Acciones rápidas:
-						</div>
-						<div className="space-y-1">
-							<Button
-								variant="outline"
-								size="sm"
-								className="w-full justify-start h-8"
-								onClick={() => setIsNewChatModalOpen(true)}
-							>
-								<MessageSquare className="h-3 w-3 mr-2" />
-								<span className="text-xs">Nueva conversación</span>
-							</Button>
-						</div>
-					</div>
-				)}
-			</div>
+			</aside>
 
 			<NewChatModal
 				open={isNewChatModalOpen}
 				onOpenChange={setIsNewChatModalOpen}
-				onSelectContact={(c) => {
-					console.log(c);
-				}}
+				onSelectContact={() => {}}
 			/>
 		</>
 	);

--- a/client/react-frontend/src/chat/components/chat-toolbar.tsx
+++ b/client/react-frontend/src/chat/components/chat-toolbar.tsx
@@ -1,35 +1,28 @@
 import {
-	Bot,
 	ChevronLeft,
 	ChevronRight,
 	HelpCircle,
 	Home,
 	MessageSquare,
-	Plus,
 	Settings,
 } from "lucide-react";
 import { type FC, useState } from "react";
 import { Button } from "@/components/ui/button";
-import type { Agent } from "../../types/Agent";
 import type { Conversation } from "../hooks/useChat";
-import { AgentsListModal } from "./agents-list-modal";
-import { CreateAgentModal } from "./create-agent-modal";
 import { NewChatModal } from "./new-chat-modal";
+import { useNavigate } from "react-router-dom";
 
 interface ChatToolbarProps {
 	selectedChat?: Conversation;
 	onGoHome: () => void;
-	onAgentSelect?: (agent: Agent) => void;
 }
 
 export const ChatToolbar: FC<ChatToolbarProps> = ({
 	selectedChat,
 	onGoHome,
-	onAgentSelect,
 }) => {
+	const navigate = useNavigate();
 	const [isCollapsed, setIsCollapsed] = useState(false);
-	const [showCreateAgent, setShowCreateAgent] = useState(false);
-	const [showAgentsList, setShowAgentsList] = useState(false);
 	const [isNewChatModalOpen, setIsNewChatModalOpen] = useState(false);
 
 	const toolbarItems = [
@@ -41,18 +34,11 @@ export const ChatToolbar: FC<ChatToolbarProps> = ({
 			variant: "ghost" as const,
 		},
 		{
-			id: "agents",
-			icon: Bot,
-			label: "Agentes",
-			onClick: () => setShowAgentsList(true),
-			variant: "ghost" as const,
-		},
-		{
-			id: "create-agent",
-			icon: Plus,
-			label: "Crear Agente",
-			onClick: () => setShowCreateAgent(true),
-			variant: "default" as const,
+			id: "agents-module",
+			icon: MessageSquare,
+			label: "Chat con Agentes",
+			onClick: () => navigate("/chat/agents"),
+			variant: "outline" as const,
 		},
 		{
 			id: "settings",
@@ -141,7 +127,7 @@ export const ChatToolbar: FC<ChatToolbarProps> = ({
 									{selectedChat.title || "Sin nombre"}
 								</div>
 								<div className="text-xs text-muted-foreground">
-									{selectedChat.type === "bot" ? "Agente" : "Usuario"}
+									Chat interno de equipo
 								</div>
 							</div>
 						</div>
@@ -168,25 +154,6 @@ export const ChatToolbar: FC<ChatToolbarProps> = ({
 					</div>
 				)}
 			</div>
-
-			{/* Modals */}
-			<CreateAgentModal
-				open={showCreateAgent}
-				onOpenChange={setShowCreateAgent}
-				onAgentCreated={(agent) => {
-					console.log("Agent created:", agent);
-					setShowCreateAgent(false);
-				}}
-			/>
-
-			<AgentsListModal
-				open={showAgentsList}
-				onOpenChange={setShowAgentsList}
-				onAgentSelect={(agent) => {
-					onAgentSelect?.(agent);
-					setShowAgentsList(false);
-				}}
-			/>
 
 			<NewChatModal
 				open={isNewChatModalOpen}

--- a/client/react-frontend/src/chat/hooks/useAgents.ts
+++ b/client/react-frontend/src/chat/hooks/useAgents.ts
@@ -7,13 +7,6 @@ import type {
 } from "../../types/Agent";
 import api from "@/lib/api";
 
-interface AgentExternalResponse {
-	respuesta?: string;
-	response?: string;
-	message?: string;
-	[key: string]: unknown;
-}
-
 export const useAgents = () => {
 	const [agents, setAgents] = useState<Agent[]>([]);
 	const [loading, setLoading] = useState<boolean>(false);
@@ -106,57 +99,9 @@ export const useAgents = () => {
 		setLoading(true);
 		setError(null);
 		try {
-			const agent = agents.find((a) => a.id === messageData.agent_id);
-			if (!agent) {
-				throw new Error("Agente no encontrado");
-			}
-
-			const agentRequest: {
-				prompt?: string;
-				systemPrompt?: string;
-				image?: string;
-				audio?: string;
-				video?: string;
-				file?: string;
-			} = {
-				prompt: messageData.content,
-				systemPrompt: (agent as any).system_prompt || "",
-			};
-
-			if (messageData.attachment_type && messageData.attachment_url) {
-				switch (messageData.attachment_type) {
-					case "image":
-						agentRequest.image = messageData.attachment_url;
-						break;
-					case "audio":
-						agentRequest.audio = messageData.attachment_url;
-						break;
-					case "video":
-						agentRequest.video = messageData.attachment_url;
-						break;
-					case "file":
-						agentRequest.file = messageData.attachment_url;
-						break;
-				}
-			}
-
-			const { data: agentResponse } = await api.post<AgentExternalResponse>(
-				agent.url,
-				agentRequest,
-			);
-
-			const agentResponseContent =
-				agentResponse.respuesta ??
-				agentResponse.response ??
-				agentResponse.message ??
-				"Sin respuesta del agente";
-
 			const { data: serverResult } = await api.post(
 				"/api/agents/message",
-				{
-					...messageData,
-					agent_response: agentResponseContent,
-				},
+				messageData,
 			);
 
 			return serverResult;

--- a/client/react-frontend/src/chat/hooks/useChatContext.tsx
+++ b/client/react-frontend/src/chat/hooks/useChatContext.tsx
@@ -1,0 +1,19 @@
+import { createContext, useContext, type PropsWithChildren } from "react";
+import { useChat } from "./useChat";
+
+type ChatContextValue = ReturnType<typeof useChat>;
+
+const ChatContext = createContext<ChatContextValue | null>(null);
+
+export function ChatProvider({ children }: PropsWithChildren) {
+	const chat = useChat();
+	return <ChatContext.Provider value={chat}>{children}</ChatContext.Provider>;
+}
+
+export function useChatContext() {
+	const context = useContext(ChatContext);
+	if (!context) {
+		throw new Error("useChatContext debe usarse dentro de ChatProvider");
+	}
+	return context;
+}

--- a/client/react-frontend/src/components/SettingsModal.tsx
+++ b/client/react-frontend/src/components/SettingsModal.tsx
@@ -382,6 +382,13 @@ interface Token {
   updated_at: string;
 }
 
+const TOKEN_LABELS: Record<string, string> = {
+  github: 'GitHub',
+  gemini: 'Gemini AI',
+  openrouter: 'OpenRouter',
+  replicate: 'Replicate',
+};
+
 const TokensSettings: FC = () => {
   const [tokens, setTokens] = useState<Token[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -502,6 +509,7 @@ const TokensSettings: FC = () => {
               <SelectContent>
                 <SelectItem value="github">GitHub</SelectItem>
                 <SelectItem value="gemini">Gemini AI</SelectItem>
+                <SelectItem value="openrouter">OpenRouter</SelectItem>
                 <SelectItem value="replicate">Replicate</SelectItem>
               </SelectContent>
             </Select>
@@ -610,7 +618,7 @@ const TokensSettings: FC = () => {
                 className="flex items-center justify-between p-3 border rounded-lg"
               >
                 <div>
-                  <p className="font-medium capitalize">{token.token_type}</p>
+                  <p className="font-medium">{TOKEN_LABELS[token.token_type] || token.token_type}</p>
                   <p className="text-sm text-muted-foreground">
                     Creado: {new Date(token.created_at).toLocaleDateString()}
                   </p>

--- a/client/react-frontend/src/main.tsx
+++ b/client/react-frontend/src/main.tsx
@@ -5,6 +5,7 @@ import { Toaster as SonnerToaster } from "sonner";
 import { ElectronWrapper } from "@/components/ElectronWrapper";
 import { ThemeProvider } from "@/contexts/theme-context";
 import AppRouter from "./AppRouter.tsx";
+import AgentsChatPage from "./chat/app/agents-page.tsx";
 import HomeChat from "./chat/app/page.tsx";
 import ProjectsPage from "./components/DashboardPage.tsx";
 import ProjectPageDemo from "./components/demo/page.tsx";
@@ -55,6 +56,7 @@ createRoot(document.getElementById("root")!).render(
 						<Route path="/projects" element={<ProjectWorkSpace />} />
 						<Route path="/landpage" element={<LandingPage />} />
 						<Route path="/chat" element={<HomeChat />} />
+						<Route path="/chat/agents" element={<AgentsChatPage />} />
 						<Route path="/help" element={<Help />} />
 						<Route path="/settings" element={<SettingsPage />} />
 						<Route path="/settings/tokens" element={<TokenManagement />} />

--- a/client/react-frontend/src/pages/Help.tsx
+++ b/client/react-frontend/src/pages/Help.tsx
@@ -4,6 +4,10 @@ import {
 	FileText,
 	Github,
 	HelpCircle,
+	LifeBuoy,
+	MessageSquare,
+	Rocket,
+	ShieldCheck,
 	Zap,
 } from "lucide-react";
 import { useMemo, useState } from "react";
@@ -28,20 +32,24 @@ type HelpItem = {
 
 export default function HelpPage() {
 	const [activeCategory, setActiveCategory] = useState<HelpCategoryId>("help");
-	const [activeItemId, setActiveItemId] = useState<string>("getting-started");
+	const [activeItemId, setActiveItemId] = useState<string>("quick-start");
 	const [search, setSearch] = useState("");
 
 	const categories = useMemo(
 		() => [
 			{
 				id: "help" as const,
-				label: "Help",
+				label: "Ayuda",
 				icon: <HelpCircle className="h-4 w-4" />,
 			},
-			{ id: "api" as const, label: "API", icon: <Code2 className="h-4 w-4" /> },
+			{
+				id: "api" as const,
+				label: "API",
+				icon: <Code2 className="h-4 w-4" />,
+			},
 			{
 				id: "updates" as const,
-				label: "Updates",
+				label: "Actualizaciones",
 				icon: <Zap className="h-4 w-4" />,
 			},
 		],
@@ -51,48 +59,161 @@ export default function HelpPage() {
 	const items = useMemo<HelpItem[]>(
 		() => [
 			{
-				id: "getting-started",
-				title: "Primeros pasos",
+				id: "quick-start",
+				title: "Guía rápida de uso",
 				category: "help",
-				summary: "Qué es SYSGD y cómo empezar.",
-				icon: <BookOpen className="h-4 w-4" />,
+				summary: "Cómo empezar a usar SYSGD en pocos pasos.",
+				icon: <Rocket className="h-4 w-4" />,
 				content: [
-					"SYSGD es un sistema para gestionar información y procesos documentales con seguridad y trazabilidad.",
+					"SYSGD centraliza trabajo colaborativo, tareas, notas, documentos y chat.",
 					"",
-					"Recomendado para comenzar:",
-					"- Inicia sesión.",
-					"- Crea/abre tu espacio de trabajo.",
-					"- Organiza documentos y permisos.",
+					"Flujo recomendado para nuevos usuarios:",
+					"1) Inicia sesión y verifica tu perfil en Configuración.",
+					"2) Crea o únete a un proyecto.",
+					"3) Usa tareas/notas para organizar trabajo interno.",
+					"4) Usa Chat interno para comunicación de equipo.",
+					"5) Usa Chat con agentes para apoyo IA especializado.",
 				],
 			},
 			{
-				id: "api-overview",
-				title: "API overview",
+				id: "chat-internal-vs-agents",
+				title: "Chat interno vs Chat con agentes",
+				category: "help",
+				summary: "Qué hace cada módulo y cuándo usarlo.",
+				icon: <MessageSquare className="h-4 w-4" />,
+				content: [
+					"Chat interno: conversaciones entre miembros del equipo (persona a persona).",
+					"Chat con agentes: conversaciones asistidas por IA para soporte, análisis o ejecución guiada.",
+					"",
+					"Buenas prácticas:",
+					"- Usa chat interno para coordinación diaria y decisiones de equipo.",
+					"- Usa chat con agentes cuando necesites ayuda IA, prompts o automatización.",
+					"- Crea una conversación por tema y luego selecciona/cambia el agente según convenga.",
+				],
+			},
+			{
+				id: "tokens-and-credits",
+				title: "Tokens personalizados y créditos",
+				category: "help",
+				summary: "Prioridad de token del usuario y consumo de créditos.",
+				icon: <ShieldCheck className="h-4 w-4" />,
+				content: [
+					"Puedes guardar tokens personales (por ejemplo Gemini u OpenRouter) desde Configuración.",
+					"",
+					"Regla de uso:",
+					"- Si existe token personal válido para el proveedor, el sistema lo prioriza.",
+					"- Si no existe, se usa el token del sistema.",
+					"",
+					"Créditos IA:",
+					"- No se descuentan créditos cuando usas token personal.",
+					"- Sí se descuentan cuando se usa token del sistema.",
+				],
+			},
+			{
+				id: "support",
+				title: "Soporte y resolución de problemas",
+				category: "help",
+				summary: "Qué revisar si algo falla y cómo pedir ayuda.",
+				icon: <LifeBuoy className="h-4 w-4" />,
+				content: [
+					"Si un módulo no responde correctamente:",
+					"- Verifica conexión y sesión activa.",
+					"- Revisa que el token API esté guardado si usas agentes IA.",
+					"- Comprueba permisos del proyecto/equipo.",
+					"",
+					"Si persiste el problema, reporta:",
+					"- Ruta y acción exacta realizada.",
+					"- Mensaje de error mostrado.",
+					"- Hora aproximada del fallo.",
+				],
+			},
+			{
+				id: "api-auth-and-users",
+				title: "API: autenticación y usuarios",
 				category: "api",
-				summary: "Resumen rápido de endpoints.",
+				summary: "Registro/login, perfil y métricas de uso.",
 				icon: <Code2 className="h-4 w-4" />,
 				content: [
-					"La API está pensada principalmente para el cliente web.",
+					"Base URL: {SERVER_URL}/api",
+					"Autenticación: Bearer token (Authorization) o sesión según flujo.",
 					"",
-					"Endpoints (resumen):",
-					"- /api/auth/*",
-					"- /api/projects/*",
-					"- /api/tasks/*",
-					"- /api/github/*",
+					"Endpoints principales:",
+					"- /api/auth/* (login, OAuth, etc.)",
+					"- /api/users/me (usuario actual)",
+					"- /api/users/usage (resumen de uso y créditos)",
+					"- /api/users/plan (plan del usuario)",
+					"- /api/users/public-users (listado público)",
 				],
 			},
 			{
-				id: "changelog",
-				title: "Cambios recientes",
-				category: "updates",
-				summary: "Notas rápidas de versión.",
+				id: "api-collaboration",
+				title: "API: colaboración (proyectos, tareas, notas)",
+				category: "api",
+				summary: "Operaciones base para gestión del trabajo.",
+				icon: <BookOpen className="h-4 w-4" />,
+				content: [
+					"Dominios principales:",
+					"- /api/projects/*",
+					"- /api/tasks/*",
+					"- /api/ideas/*",
+					"- /api/notes/* y /api/projects/:id/notes",
+					"- /api/members/* e /api/invitations/*",
+					"",
+					"IA en tareas:",
+					"- /api/tasks/generate (generación asistida)",
+				],
+			},
+			{
+				id: "api-chat-and-agents",
+				title: "API: chat y agentes IA",
+				category: "api",
+				summary: "Conversaciones internas y flujo de agentes.",
+				icon: <MessageSquare className="h-4 w-4" />,
+				content: [
+					"Chat interno:",
+					"- /api/chat/*",
+					"",
+					"Agentes:",
+					"- /api/agents/* (CRUD de agentes y mensajes)",
+					"- /api/agents/message (envío centralizado desde backend)",
+					"",
+					"Proveedores IA disponibles:",
+					"- /api/openrouter",
+					"- /api/openrouterai",
+					"- /api/generate (flujo Gemini)",
+					"- /api/qwen",
+				],
+			},
+			{
+				id: "api-files-and-integrations",
+				title: "API: archivos, tokens e integraciones",
+				category: "api",
+				summary: "Uploads, GitHub, tokens y otros módulos.",
 				icon: <FileText className="h-4 w-4" />,
 				content: [
-					"Aquí puedes mantener un changelog simple para los usuarios.",
+					"Archivos:",
+					"- /api/uploads",
+					"- /api/upload",
 					"",
-					"Ejemplo:",
-					"- Integración GitHub: repositorio por proyecto y token por usuario.",
-					"- Tokens cifrados en BD.",
+					"Integraciones y configuración:",
+					"- /api/github/*",
+					"- /api/tokens/* (guardar/eliminar/listar tokens)",
+					"- /api/verification/*",
+					"- /api/crypto-payments/*",
+					"- /api/time-entries/*",
+				],
+			},
+			{
+				id: "updates-recent",
+				title: "Novedades recientes",
+				category: "updates",
+				summary: "Resumen de mejoras funcionales visibles para usuarios.",
+				icon: <Zap className="h-4 w-4" />,
+				content: [
+					"- Mejora del módulo de chat con separación entre chat interno y chat con agentes.",
+					"- Flujo de agentes más claro: conversación por tema + selección/cambio de agente.",
+					"- Soporte para tokens personalizados de proveedores IA en configuración.",
+					"- Mejoras visuales y de responsividad en componentes principales de chat.",
 				],
 			},
 		],
@@ -106,7 +227,8 @@ export default function HelpPage() {
 		return base.filter(
 			(i) =>
 				i.title.toLowerCase().includes(q) ||
-				i.summary.toLowerCase().includes(q),
+				i.summary.toLowerCase().includes(q) ||
+				i.content.join(" ").toLowerCase().includes(q),
 		);
 	}, [items, activeCategory, search]);
 
@@ -121,11 +243,9 @@ export default function HelpPage() {
 			<div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
 				<div className="flex items-start justify-between gap-4">
 					<div>
-						<h1 className="text-3xl font-bold tracking-tight">
-							Centro de ayuda
-						</h1>
+						<h1 className="text-3xl font-bold tracking-tight">Centro de ayuda</h1>
 						<p className="text-muted-foreground mt-2">
-							Categorías arriba, índice lateral y contenido por sección.
+							Guías funcionales del sistema y referencia de endpoints API por módulos.
 						</p>
 					</div>
 					<Button variant="outline" asChild>
@@ -172,32 +292,24 @@ export default function HelpPage() {
 											type="button"
 											onClick={() => setActiveItemId(i.id)}
 											className={`w-full rounded-md border p-3 text-left transition-colors hover:bg-muted ${
-												activeItemId === i.id
-													? "border-primary"
-													: "border-border"
+												activeItemId === i.id ? "border-primary" : "border-border"
 											}`}
 										>
 											<div className="flex items-start justify-between gap-3">
 												<div className="flex items-center gap-2">
-													<span className="text-muted-foreground">
-														{i.icon}
-													</span>
+													<span className="text-muted-foreground">{i.icon}</span>
 													<span className="font-medium">{i.title}</span>
 												</div>
 												<Badge variant="secondary" className="shrink-0">
 													{i.category.toUpperCase()}
 												</Badge>
 											</div>
-											<p className="text-sm text-muted-foreground mt-2">
-												{i.summary}
-											</p>
+											<p className="text-sm text-muted-foreground mt-2">{i.summary}</p>
 										</button>
 									))}
 
 									{filteredItems.length === 0 && (
-										<div className="text-sm text-muted-foreground p-3">
-											No hay resultados.
-										</div>
+										<div className="text-sm text-muted-foreground p-3">No hay resultados.</div>
 									)}
 								</div>
 							</ScrollArea>
@@ -214,10 +326,7 @@ export default function HelpPage() {
 						<CardContent>
 							<div className="space-y-3">
 								{activeItem.content.map((line, idx) => (
-									<p
-										key={`${activeItem.id}-${idx}`}
-										className="text-sm leading-6"
-									>
+									<p key={`${activeItem.id}-${idx}`} className="text-sm leading-6">
 										{line}
 									</p>
 								))}
@@ -236,10 +345,7 @@ export default function HelpPage() {
 									</a>
 								</div>
 								<Button variant="outline" asChild className="gap-2">
-									<Link
-										to="https://github.com/lazaroysr96/sysgd/"
-										target="_blank"
-									>
+									<Link to="https://github.com/lazaroysr96/sysgd/" target="_blank">
 										<Github className="h-4 w-4" />
 										GitHub
 									</Link>

--- a/client/react-frontend/src/pages/SettingPage.tsx
+++ b/client/react-frontend/src/pages/SettingPage.tsx
@@ -68,6 +68,13 @@ interface Token {
 	updated_at: string;
 }
 
+const TOKEN_LABELS: Record<string, string> = {
+	github: "GitHub",
+	gemini: "Gemini AI",
+	openrouter: "OpenRouter",
+	replicate: "Replicate",
+};
+
 const TokensSection: FC = () => {
 	const [tokens, setTokens] = useState<Token[]>([]);
 	const [isLoading, setIsLoading] = useState(true);
@@ -177,6 +184,7 @@ const TokensSection: FC = () => {
 							<SelectContent>
 								<SelectItem value="github">GitHub</SelectItem>
 								<SelectItem value="gemini">Gemini AI</SelectItem>
+								<SelectItem value="openrouter">OpenRouter</SelectItem>
 								<SelectItem value="replicate">Replicate</SelectItem>
 							</SelectContent>
 						</Select>
@@ -278,7 +286,7 @@ const TokensSection: FC = () => {
 								className="flex items-center justify-between p-3 border rounded-lg"
 							>
 								<div>
-									<p className="font-medium capitalize">{token.token_type}</p>
+									<p className="font-medium">{TOKEN_LABELS[token.token_type] || token.token_type}</p>
 									<p className="text-xs text-muted-foreground">
 										Creado:{" "}
 										{new Date(token.created_at).toLocaleDateString("es-ES")}

--- a/server/node-server/schema.sql
+++ b/server/node-server/schema.sql
@@ -147,7 +147,7 @@ CREATE INDEX IF NOT EXISTS idx_time_entries_project_id ON time_entries(project_i
 CREATE TABLE IF NOT EXISTS user_tokens (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-  token_type TEXT NOT NULL CHECK (token_type IN ('github', 'gemini', 'replicate')),
+  token_type TEXT NOT NULL CHECK (token_type IN ('github', 'gemini', 'replicate', 'openrouter')),
   encrypted_token BYTEA NOT NULL,
   iv BYTEA NOT NULL,
   created_at TIMESTAMP DEFAULT NOW(),

--- a/server/node-server/src/controllers/token.controller.ts
+++ b/server/node-server/src/controllers/token.controller.ts
@@ -33,7 +33,7 @@ export class TokenController {
 			return;
 		}
 
-		if (!["github", "gemini", "replicate"].includes(tokenType)) {
+		if (!["github", "gemini", "replicate", "openrouter"].includes(tokenType)) {
 			res.status(400).json({ error: "Tipo de token no soportado" });
 			return;
 		}

--- a/server/node-server/src/openRouterAgent.ts
+++ b/server/node-server/src/openRouterAgent.ts
@@ -27,10 +27,6 @@ const imageQuestionKeywords = [
 // Si contiene palabras de pregunta → texto
 // Solo si explícitamente pide generar → imagen
 
-if (!OPENROUTER_API_KEY) {
-	throw new Error("❌ Falta OPENROUTER_API_KEY en .env");
-}
-
 const API_BASE = "https://openrouter.ai/api/v1";
 
 /**
@@ -43,6 +39,10 @@ async function callOpenRouterChat(
 	customToken?: string,
 ): Promise<string> {
 	const token = customToken || OPENROUTER_API_KEY;
+
+	if (!token) {
+		throw new Error("No se encontró token de OpenRouter (usuario ni sistema)");
+	}
 
 	console.log("Using system:", systemPrompt);
 
@@ -94,11 +94,18 @@ console.log("Enviando esto...",{
 async function generateImageOpenRouter(
 	prompt: string,
 	model: string = "google/gemini-2.5-flash-image-preview",
+ 	customToken?: string,
 ): Promise<string> {
+	const token = customToken || OPENROUTER_API_KEY;
+
+	if (!token) {
+		throw new Error("No se encontró token de OpenRouter (usuario ni sistema)");
+	}
+
 	const response = await fetch(`${API_BASE}/chat/completions`, {
 		method: "POST",
 		headers: {
-			Authorization: `Bearer ${OPENROUTER_API_KEY}`,
+			Authorization: `Bearer ${token}`,
 			"Content-Type": "application/json",
 			"HTTP-Referer": "https://tu-app.com",
 			"X-Title": "SYSGD Chat",
@@ -144,7 +151,7 @@ export async function processAgentRequest(
 			prompt.toLowerCase().includes("genera una imagen") &&
 			!force_text_response
 		) {
-			const imageUrl = await generateImageOpenRouter(prompt);
+			const imageUrl = await generateImageOpenRouter(prompt, model, customToken);
 			respuesta = "Aquí tienes la imagen generada:";
 			attachment_type = "image";
 			attachment_url = imageUrl;

--- a/server/node-server/src/routes/agents.ts
+++ b/server/node-server/src/routes/agents.ts
@@ -8,6 +8,7 @@ import {
   deleteAgent,
   sendMessageToAgent
 } from '../controllers/agents.controller';
+import { checkAICredits } from '../middlewares/usageLimits.middleware';
 
 const router = Router();
 
@@ -29,7 +30,7 @@ router.delete('/:id', isAuthenticated, async (req: Request, res: Response) => {
 });
 
 // Enviar mensaje a agente
-router.post('/message', isAuthenticated, async (req: Request, res: Response) => {
+router.post('/message', isAuthenticated, checkAICredits, async (req: Request, res: Response) => {
   await sendMessageToAgent(req, res);
 });
 


### PR DESCRIPTION
### Motivation
- Unificar el estado del módulo de chat para evitar hooks duplicados y desincronización entre la lista de conversaciones y la vista de conversación. 
- Clarificar el dominio separando las conversaciones internas de equipo del flujo con agentes externos para reducir acoplamiento y facilitar futuros refactors. 

### Description
- Se añade `ChatProvider` y `useChatContext` y se envuelve la pantalla principal del chat con `ChatProvider` para exponer una única fuente de verdad (`useChatContext`). 
- Se refactoriza `ChatConversation`, `ChatSidebar` y `ChatInterface` para consumir `useChatContext` y se elimina la lógica embebida de `selectedAgent` / envío a agentes desde el flujo principal. 
- Se actualiza `ChatToolbar` para quitar modales de agentes y añadir un acceso al módulo separado ` /chat/agents`, y se crea la nueva página `AgentsChatPage` con ruta registrada en `main.tsx`. 
- Ajustes UX en sidebar para desactivar el filtro de agentes y comunicar que el chat con agentes vive en un módulo independiente. 

### Testing
- Se ejecutó la compilación de frontend con `cd client/react-frontend && npm run build` y finalizó correctamente (TypeScript + Vite build). 
- Se arrancó el servidor de desarrollo (`vite`) y se generaron capturas automatizadas de UI con Playwright para `/chat` y `/chat/agents` para validar visualmente los cambios. 
- Se verificó el estado de Git y el commit resultante mediante `git status` y `git log` para confirmar los archivos modificados y el último commit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f5f59ce9c8322bc0a1dcb2451bea4)