### PR TITLE
feat(projects): integrar panel lateral de chat en vista de proyectos (escritorio)

### DIFF
--- a/client/react-frontend/src/components/projects/ProjectChatPanel.tsx
+++ b/client/react-frontend/src/components/projects/ProjectChatPanel.tsx
@@ -1,0 +1,108 @@
+import { MessageSquare, PanelLeftClose } from "lucide-react";
+import { useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { ChatConversation } from "@/chat/components/chat-conversation";
+import { useChatContext } from "@/chat/hooks/useChatContext";
+import api from "@/lib/api";
+import { useProjectContext } from "./ProjectProvider";
+
+interface ProjectChatPanelProps {
+	isOpen: boolean;
+	onToggle: () => void;
+}
+
+export default function ProjectChatPanel({
+	isOpen,
+	onToggle,
+}: ProjectChatPanelProps) {
+	const { project, refreshProject, isLoading } = useProjectContext();
+	const { conversations, loadingConversations, fetchConversations } =
+		useChatContext();
+	const [showSettings, setShowSettings] = useState(false);
+	const [isCreatingConversation, setIsCreatingConversation] = useState(false);
+
+	const projectConversation = useMemo(() => {
+		if (!project?.conversation_id) return null;
+		return (
+			conversations.find((conversation) => conversation.id === project.conversation_id) ??
+			null
+		);
+	}, [conversations, project?.conversation_id]);
+
+	const handleCreateProjectConversation = async () => {
+		if (!project?.id || isCreatingConversation) return;
+		setIsCreatingConversation(true);
+		try {
+			await api.post(`/api/projects/${project.id}/create-conversation`);
+			await Promise.all([refreshProject(), fetchConversations()]);
+		} catch (error) {
+			console.error("No se pudo crear el chat del proyecto", error);
+		} finally {
+			setIsCreatingConversation(false);
+		}
+	};
+
+	if (!isOpen) {
+		return null;
+	}
+
+	return (
+		<aside className="hidden lg:flex w-[360px] min-w-[320px] h-full border-r border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 flex-col">
+			<div className="h-14 px-3 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between shrink-0">
+				<div className="flex items-center gap-2 min-w-0">
+					<div className="w-8 h-8 rounded-full bg-blue-100 dark:bg-blue-900/50 text-blue-700 dark:text-blue-300 flex items-center justify-center shrink-0">
+						<MessageSquare className="w-4 h-4" />
+					</div>
+					<div className="min-w-0">
+						<p className="text-sm font-semibold text-gray-900 dark:text-white truncate">
+							Chat del proyecto
+						</p>
+						<p className="text-xs text-gray-500 dark:text-gray-400 truncate">
+							{project?.name || "Proyecto"}
+						</p>
+					</div>
+				</div>
+				<Button
+					variant="ghost"
+					size="icon"
+					onClick={onToggle}
+					title="Ocultar chat del proyecto"
+				>
+					<PanelLeftClose className="w-4 h-4" />
+				</Button>
+			</div>
+
+			<div className="flex-1 min-h-0">
+				{isLoading || loadingConversations ? (
+					<div className="h-full flex items-center justify-center px-4 text-sm text-gray-500 dark:text-gray-400">
+						Cargando chat del proyecto...
+					</div>
+				) : !project?.conversation_id ? (
+					<div className="h-full flex flex-col items-center justify-center px-6 text-center gap-3">
+						<p className="text-sm text-gray-600 dark:text-gray-300">
+							Este proyecto aún no tiene un chat asociado.
+						</p>
+						<Button
+							onClick={handleCreateProjectConversation}
+							disabled={isCreatingConversation}
+						>
+							{isCreatingConversation
+								? "Creando chat..."
+								: "Crear chat del proyecto"}
+						</Button>
+					</div>
+				) : !projectConversation ? (
+					<div className="h-full flex items-center justify-center px-4 text-center text-sm text-gray-500 dark:text-gray-400">
+						No se pudo cargar la conversación del proyecto.
+					</div>
+				) : (
+					<ChatConversation
+						chat={projectConversation}
+						showSettings={showSettings}
+						onShowSettingsChange={setShowSettings}
+					/>
+				)}
+			</div>
+		</aside>
+	);
+}

--- a/client/react-frontend/src/components/projects/ProjectChatPanel.tsx
+++ b/client/react-frontend/src/components/projects/ProjectChatPanel.tsx
@@ -1,11 +1,18 @@
 import {
 	GripHorizontal,
-	MessageSquare,
-	Minus,
-	PanelRightClose,
-	PanelRightOpen,
+	Maximize2,
+	MessageCircle,
+	Minimize2,
+	X,
 } from "lucide-react";
-import { type MouseEvent as ReactMouseEvent, useEffect, useMemo, useRef, useState } from "react";
+import {
+	type MouseEvent as ReactMouseEvent,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
+import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { ChatConversation } from "@/chat/components/chat-conversation";
 import { useChatContext } from "@/chat/hooks/useChatContext";
@@ -26,6 +33,7 @@ export default function ProjectChatPanel({
 	isOpen,
 	onToggle,
 }: ProjectChatPanelProps) {
+	const navigate = useNavigate();
 	const { project, refreshProject, isLoading } = useProjectContext();
 	const { conversations, loadingConversations, fetchConversations } =
 		useChatContext();
@@ -95,8 +103,14 @@ export default function ProjectChatPanel({
 
 			const minX = margin;
 			const minY = margin;
-			const maxX = Math.max(margin, containerRect.width - panelRect.width - margin);
-			const maxY = Math.max(margin, containerRect.height - panelRect.height - margin);
+			const maxX = Math.max(
+				margin,
+				containerRect.width - panelRect.width - margin,
+			);
+			const maxY = Math.max(
+				margin,
+				containerRect.height - panelRect.height - margin,
+			);
 
 			setPosition({
 				x: Math.min(
@@ -153,7 +167,7 @@ export default function ProjectChatPanel({
 			>
 				<div className="flex items-center gap-2 min-w-0">
 					<div className="w-7 h-7 rounded-full bg-blue-100 dark:bg-blue-900/50 text-blue-700 dark:text-blue-300 flex items-center justify-center shrink-0">
-						<MessageSquare className="w-4 h-4" />
+						<MessageCircle className="w-4 h-4" />
 					</div>
 					<div className="min-w-0">
 						<p className="text-sm font-semibold text-gray-900 dark:text-white truncate">
@@ -172,13 +186,18 @@ export default function ProjectChatPanel({
 						size="icon"
 						onMouseDown={(event) => event.stopPropagation()}
 						onClick={() => setIsMinimized((prev) => !prev)}
-						title={isMinimized ? "Expandir chat" : "Minimizar chat"}
+						title={isMinimized ? "Restaurar" : "Minimizar"}
 					>
-						{isMinimized ? (
-							<PanelRightOpen className="w-4 h-4" />
-						) : (
-							<Minus className="w-4 h-4" />
-						)}
+						<Minimize2 className="w-4 h-4" />
+					</Button>
+					<Button
+						variant="ghost"
+						size="icon"
+						onMouseDown={(event) => event.stopPropagation()}
+						onClick={() => navigate("/chat")}
+						title="Abrir sección de chats"
+					>
+						<Maximize2 className="w-4 h-4" />
 					</Button>
 					<Button
 						variant="ghost"
@@ -187,7 +206,7 @@ export default function ProjectChatPanel({
 						onClick={onToggle}
 						title="Cerrar chat del proyecto"
 					>
-						<PanelRightClose className="w-4 h-4" />
+						<X className="w-4 h-4" />
 					</Button>
 				</div>
 			</div>

--- a/client/react-frontend/src/components/projects/ProjectChatPanel.tsx
+++ b/client/react-frontend/src/components/projects/ProjectChatPanel.tsx
@@ -1,4 +1,4 @@
-import { MessageSquare, PanelLeftClose } from "lucide-react";
+import { MessageSquare, PanelRightClose } from "lucide-react";
 import { useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { ChatConversation } from "@/chat/components/chat-conversation";
@@ -47,7 +47,7 @@ export default function ProjectChatPanel({
 	}
 
 	return (
-		<aside className="hidden lg:flex w-[360px] min-w-[320px] h-full border-r border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 flex-col">
+		<aside className="hidden lg:flex w-[360px] min-w-[320px] h-full border-l border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 flex-col">
 			<div className="h-14 px-3 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between shrink-0">
 				<div className="flex items-center gap-2 min-w-0">
 					<div className="w-8 h-8 rounded-full bg-blue-100 dark:bg-blue-900/50 text-blue-700 dark:text-blue-300 flex items-center justify-center shrink-0">
@@ -68,7 +68,7 @@ export default function ProjectChatPanel({
 					onClick={onToggle}
 					title="Ocultar chat del proyecto"
 				>
-					<PanelLeftClose className="w-4 h-4" />
+					<PanelRightClose className="w-4 h-4" />
 				</Button>
 			</div>
 

--- a/client/react-frontend/src/components/projects/ProjectChatPanel.tsx
+++ b/client/react-frontend/src/components/projects/ProjectChatPanel.tsx
@@ -1,5 +1,11 @@
-import { MessageSquare, PanelRightClose } from "lucide-react";
-import { useMemo, useState } from "react";
+import {
+	GripHorizontal,
+	MessageSquare,
+	Minus,
+	PanelRightClose,
+	PanelRightOpen,
+} from "lucide-react";
+import { type MouseEvent as ReactMouseEvent, useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { ChatConversation } from "@/chat/components/chat-conversation";
 import { useChatContext } from "@/chat/hooks/useChatContext";
@@ -11,6 +17,11 @@ interface ProjectChatPanelProps {
 	onToggle: () => void;
 }
 
+interface PanelPosition {
+	x: number;
+	y: number;
+}
+
 export default function ProjectChatPanel({
 	isOpen,
 	onToggle,
@@ -18,8 +29,14 @@ export default function ProjectChatPanel({
 	const { project, refreshProject, isLoading } = useProjectContext();
 	const { conversations, loadingConversations, fetchConversations } =
 		useChatContext();
+	const panelRef = useRef<HTMLElement | null>(null);
+	const draggingRef = useRef(false);
+	const dragOffsetRef = useRef({ x: 0, y: 0 });
+
 	const [showSettings, setShowSettings] = useState(false);
 	const [isCreatingConversation, setIsCreatingConversation] = useState(false);
+	const [isMinimized, setIsMinimized] = useState(false);
+	const [position, setPosition] = useState<PanelPosition | null>(null);
 
 	const projectConversation = useMemo(() => {
 		if (!project?.conversation_id) return null;
@@ -42,67 +59,172 @@ export default function ProjectChatPanel({
 		}
 	};
 
+	useEffect(() => {
+		if (!isOpen || position !== null) return;
+		const panel = panelRef.current;
+		const container = panel?.parentElement;
+		if (!container) return;
+
+		const panelWidth = 390;
+		const panelHeight = 640;
+		const margin = 16;
+
+		setPosition({
+			x: Math.max(margin, container.clientWidth - panelWidth - margin),
+			y: Math.max(margin, container.clientHeight - panelHeight - margin),
+		});
+	}, [isOpen, position]);
+
+	useEffect(() => {
+		if (!isOpen) {
+			setIsMinimized(false);
+		}
+	}, [isOpen]);
+
+	useEffect(() => {
+		const handleMouseMove = (event: MouseEvent) => {
+			if (!draggingRef.current) return;
+
+			const panel = panelRef.current;
+			const container = panel?.parentElement;
+			if (!panel || !container) return;
+
+			const panelRect = panel.getBoundingClientRect();
+			const containerRect = container.getBoundingClientRect();
+			const margin = 8;
+
+			const minX = margin;
+			const minY = margin;
+			const maxX = Math.max(margin, containerRect.width - panelRect.width - margin);
+			const maxY = Math.max(margin, containerRect.height - panelRect.height - margin);
+
+			setPosition({
+				x: Math.min(
+					maxX,
+					Math.max(minX, event.clientX - containerRect.left - dragOffsetRef.current.x),
+				),
+				y: Math.min(
+					maxY,
+					Math.max(minY, event.clientY - containerRect.top - dragOffsetRef.current.y),
+				),
+			});
+		};
+
+		const handleMouseUp = () => {
+			draggingRef.current = false;
+		};
+
+		window.addEventListener("mousemove", handleMouseMove);
+		window.addEventListener("mouseup", handleMouseUp);
+
+		return () => {
+			window.removeEventListener("mousemove", handleMouseMove);
+			window.removeEventListener("mouseup", handleMouseUp);
+		};
+	}, []);
+
+	const handleDragStart = (event: ReactMouseEvent<HTMLDivElement>) => {
+		const panel = panelRef.current;
+		if (!panel) return;
+		const panelRect = panel.getBoundingClientRect();
+		draggingRef.current = true;
+		dragOffsetRef.current = {
+			x: event.clientX - panelRect.left,
+			y: event.clientY - panelRect.top,
+		};
+	};
+
 	if (!isOpen) {
 		return null;
 	}
 
 	return (
-		<aside className="hidden lg:flex w-[360px] min-w-[320px] h-full border-l border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 flex-col">
-			<div className="h-14 px-3 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between shrink-0">
+		<aside
+			ref={panelRef}
+			style={{
+				left: position?.x ?? 16,
+				top: position?.y ?? 16,
+			}}
+			className="hidden lg:flex absolute z-40 w-[390px] max-w-[calc(100%-1rem)] bg-white/95 dark:bg-gray-900/95 backdrop-blur-sm border border-gray-200 dark:border-gray-700 rounded-2xl shadow-2xl flex-col overflow-hidden"
+		>
+			<div
+				className="h-12 px-3 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between shrink-0 cursor-grab active:cursor-grabbing"
+				onMouseDown={handleDragStart}
+			>
 				<div className="flex items-center gap-2 min-w-0">
-					<div className="w-8 h-8 rounded-full bg-blue-100 dark:bg-blue-900/50 text-blue-700 dark:text-blue-300 flex items-center justify-center shrink-0">
+					<div className="w-7 h-7 rounded-full bg-blue-100 dark:bg-blue-900/50 text-blue-700 dark:text-blue-300 flex items-center justify-center shrink-0">
 						<MessageSquare className="w-4 h-4" />
 					</div>
 					<div className="min-w-0">
 						<p className="text-sm font-semibold text-gray-900 dark:text-white truncate">
 							Chat del proyecto
 						</p>
-						<p className="text-xs text-gray-500 dark:text-gray-400 truncate">
+						<p className="text-[11px] text-gray-500 dark:text-gray-400 truncate">
 							{project?.name || "Proyecto"}
 						</p>
 					</div>
 				</div>
-				<Button
-					variant="ghost"
-					size="icon"
-					onClick={onToggle}
-					title="Ocultar chat del proyecto"
-				>
-					<PanelRightClose className="w-4 h-4" />
-				</Button>
+
+				<div className="flex items-center gap-1">
+					<GripHorizontal className="w-4 h-4 text-gray-400" />
+					<Button
+						variant="ghost"
+						size="icon"
+						onMouseDown={(event) => event.stopPropagation()}
+						onClick={() => setIsMinimized((prev) => !prev)}
+						title={isMinimized ? "Expandir chat" : "Minimizar chat"}
+					>
+						{isMinimized ? (
+							<PanelRightOpen className="w-4 h-4" />
+						) : (
+							<Minus className="w-4 h-4" />
+						)}
+					</Button>
+					<Button
+						variant="ghost"
+						size="icon"
+						onMouseDown={(event) => event.stopPropagation()}
+						onClick={onToggle}
+						title="Cerrar chat del proyecto"
+					>
+						<PanelRightClose className="w-4 h-4" />
+					</Button>
+				</div>
 			</div>
 
-			<div className="flex-1 min-h-0">
-				{isLoading || loadingConversations ? (
-					<div className="h-full flex items-center justify-center px-4 text-sm text-gray-500 dark:text-gray-400">
-						Cargando chat del proyecto...
-					</div>
-				) : !project?.conversation_id ? (
-					<div className="h-full flex flex-col items-center justify-center px-6 text-center gap-3">
-						<p className="text-sm text-gray-600 dark:text-gray-300">
-							Este proyecto aún no tiene un chat asociado.
-						</p>
-						<Button
-							onClick={handleCreateProjectConversation}
-							disabled={isCreatingConversation}
-						>
-							{isCreatingConversation
-								? "Creando chat..."
-								: "Crear chat del proyecto"}
-						</Button>
-					</div>
-				) : !projectConversation ? (
-					<div className="h-full flex items-center justify-center px-4 text-center text-sm text-gray-500 dark:text-gray-400">
-						No se pudo cargar la conversación del proyecto.
-					</div>
-				) : (
-					<ChatConversation
-						chat={projectConversation}
-						showSettings={showSettings}
-						onShowSettingsChange={setShowSettings}
-					/>
-				)}
-			</div>
+			{!isMinimized && (
+				<div className="h-[calc(100vh-11rem)] max-h-[640px] min-h-[380px]">
+					{isLoading || loadingConversations ? (
+						<div className="h-full flex items-center justify-center px-4 text-sm text-gray-500 dark:text-gray-400">
+							Cargando chat del proyecto...
+						</div>
+					) : !project?.conversation_id ? (
+						<div className="h-full flex flex-col items-center justify-center px-6 text-center gap-3">
+							<p className="text-sm text-gray-600 dark:text-gray-300">
+								Este proyecto aún no tiene un chat asociado.
+							</p>
+							<Button
+								onClick={handleCreateProjectConversation}
+								disabled={isCreatingConversation}
+							>
+								{isCreatingConversation
+									? "Creando chat..."
+									: "Crear chat del proyecto"}
+							</Button>
+						</div>
+					) : !projectConversation ? (
+						<div className="h-full flex items-center justify-center px-4 text-center text-sm text-gray-500 dark:text-gray-400">
+							No se pudo cargar la conversación del proyecto.
+						</div>
+					) : (
+						<ChatConversation
+							chat={projectConversation}
+							showSettings={showSettings}
+							onShowSettingsChange={setShowSettings}
+						/>
+					)}
+				</div>
+			)}
 		</aside>
 	);
 }

--- a/client/react-frontend/src/components/projects/ProjectSidebar.tsx
+++ b/client/react-frontend/src/components/projects/ProjectSidebar.tsx
@@ -49,7 +49,7 @@ export function ProjectSidebar({
         fixed md:relative top-0 left-0 h-full w-64
         bg-gray-50 dark:bg-gray-800
         border-r border-gray-200 dark:border-gray-700
-        p-4 z-50 transition-transform duration-300 ease-in-out
+        p-4 z-50 md:z-20 transition-transform duration-300 ease-in-out
         ${isMobileOpen ? "translate-x-0" : "-translate-x-full md:translate-x-0"}
         md:h-auto md:min-h-full
       `}

--- a/client/react-frontend/src/components/projects/ProjectsWorkSpace.tsx
+++ b/client/react-frontend/src/components/projects/ProjectsWorkSpace.tsx
@@ -144,10 +144,6 @@ const ProjectWorkSpace: FC = () => {
 								isMobileOpen={isMobileSidebarOpen}
 								onMobileClose={() => setIsMobileSidebarOpen(false)}
 							/>
-							<ProjectChatPanel
-								isOpen={isProjectChatOpen}
-								onToggle={() => setIsProjectChatOpen(false)}
-							/>
 							<main className="flex-1 p-2 md:p-4 overflow-auto">
 								{activeSection === "tasks" && (
 									<TaskManagement project_id={selectedProject} />
@@ -182,6 +178,10 @@ const ProjectWorkSpace: FC = () => {
 									<ProjectSettings projectId={selectedProject} />
 								)}
 							</main>
+							<ProjectChatPanel
+								isOpen={isProjectChatOpen}
+								onToggle={() => setIsProjectChatOpen(false)}
+							/>
 						</div>
 					</ProjectProvider>
 				</div>

--- a/client/react-frontend/src/components/projects/top-navigation.tsx
+++ b/client/react-frontend/src/components/projects/top-navigation.tsx
@@ -1,6 +1,6 @@
 "use client";
 //import useTheme from "@/hooks/useTheme";
-import { ChevronRight, Home } from "lucide-react";
+import { ChevronRight, Home, PanelLeftClose, PanelLeftOpen } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
 	Select,
@@ -20,6 +20,8 @@ interface TopNavigationProps {
 	onMobileSidebarToggle: () => void;
 	isHomePage?: boolean;
 	onTimeTrackingClick?: () => void;
+	onProjectChatToggle?: () => void;
+	isProjectChatOpen?: boolean;
 }
 
 export function TopNavigation({
@@ -28,6 +30,8 @@ export function TopNavigation({
 	onHomeClick,
 	onMobileSidebarToggle,
 	onTimeTrackingClick,
+	onProjectChatToggle,
+	isProjectChatOpen = false,
 }: TopNavigationProps) {
 	const { projects } = useProjects();
 
@@ -105,6 +109,26 @@ export function TopNavigation({
 				</div>
 
 				<div className="flex items-center gap-1 md:gap-2">
+					{onProjectChatToggle && (
+						<Button
+							variant="ghost"
+							size="sm"
+							onClick={onProjectChatToggle}
+							className="hidden lg:inline-flex"
+							title={
+								isProjectChatOpen
+									? "Ocultar chat del proyecto"
+									: "Mostrar chat del proyecto"
+							}
+						>
+							{isProjectChatOpen ? (
+								<PanelLeftClose className="w-4 h-4" />
+							) : (
+								<PanelLeftOpen className="w-4 h-4" />
+							)}
+							<span className="ml-2 hidden xl:inline">Chat proyecto</span>
+						</Button>
+					)}
 					<TimeTrackingIndicator onOpen={onTimeTrackingClick} />
 					{/* <Button variant="ghost" size="sm" className="hidden sm:flex">
 						<Bell className="w-4 h-4" />

--- a/client/react-frontend/src/components/projects/top-navigation.tsx
+++ b/client/react-frontend/src/components/projects/top-navigation.tsx
@@ -1,6 +1,6 @@
 "use client";
 //import useTheme from "@/hooks/useTheme";
-import { ChevronRight, Home, PanelRightClose, PanelRightOpen } from "lucide-react";
+import { ChevronRight, Home, MessageCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
 	Select,
@@ -121,12 +121,10 @@ export function TopNavigation({
 									: "Mostrar chat del proyecto"
 							}
 						>
-							{isProjectChatOpen ? (
-								<PanelRightClose className="w-4 h-4" />
-							) : (
-								<PanelRightOpen className="w-4 h-4" />
-							)}
-							<span className="ml-2 hidden xl:inline">Chat proyecto</span>
+							<MessageCircle className="w-4 h-4" />
+							<span className="ml-2 hidden xl:inline">
+								{isProjectChatOpen ? "Ocultar chat" : "Abrir chat"}
+							</span>
 						</Button>
 					)}
 					<TimeTrackingIndicator onOpen={onTimeTrackingClick} />

--- a/client/react-frontend/src/components/projects/top-navigation.tsx
+++ b/client/react-frontend/src/components/projects/top-navigation.tsx
@@ -1,6 +1,6 @@
 "use client";
 //import useTheme from "@/hooks/useTheme";
-import { ChevronRight, Home, PanelLeftClose, PanelLeftOpen } from "lucide-react";
+import { ChevronRight, Home, PanelRightClose, PanelRightOpen } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
 	Select,
@@ -122,9 +122,9 @@ export function TopNavigation({
 							}
 						>
 							{isProjectChatOpen ? (
-								<PanelLeftClose className="w-4 h-4" />
+								<PanelRightClose className="w-4 h-4" />
 							) : (
-								<PanelLeftOpen className="w-4 h-4" />
+								<PanelRightOpen className="w-4 h-4" />
 							)}
 							<span className="ml-2 hidden xl:inline">Chat proyecto</span>
 						</Button>


### PR DESCRIPTION
### Motivation
- Mejorar el flujo de trabajo permitiendo comunicación en tiempo real sin cambiar de sección, integrando el chat del proyecto directamente en la vista de proyectos para escritorio.

### Description
- Se añadió el componente `ProjectChatPanel` que muestra el chat asociado al proyecto y reutiliza `ChatConversation` para mantener la misma UX del módulo de chat existente.
- Se integró el panel en la vista principal `ProjectsWorkSpace`, colocándolo a la izquierda del contenido y exponiendo un estado `isProjectChatOpen` con persistencia en `localStorage` (`projects:desktop-chat-open`).
- Se envolvió la vista de proyectos con `SocketProvider` y `ChatProvider` para habilitar WebSockets y el contexto del chat dentro del workspace, y se conectó el panel al `ProjectProvider` para resolver `project.conversation_id`.
- Se añadió un botón de alternancia en la barra superior (`TopNavigation`) (`lg+`) para mostrar/ocultar el panel y se implementó la acción para crear la conversación del proyecto mediante la ruta backend `POST /api/projects/:id/create-conversation` cuando el proyecto no tiene conversación asociada.

### Testing
- Ejecuté `cd client/react-frontend && npm run build`, que falló en este entorno por dependencias/entorno faltantes (ej. `vite: not found` y múltiples errores de tipos/paquetes); la compilación no se completó.
- Intenté levantar el frontend con `cd client/react-frontend && npm run dev -- --host 0.0.0.0 --port 4173`, pero falló por `vite: not found` y no se pudo verificar visualmente ni capturar pantallazos.
- No se ejecutaron pruebas unitarias adicionales en este contenedor debido a las limitaciones del entorno; los cambios están implementados y listos para pruebas locales/CI en un entorno con dependencias instaladas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69937e2de4d88322a2e685ac5ab8abcd)