### PR TITLE
Add Apklis promotional banner for Gestor Contable TCP

### DIFF
--- a/sysgd-cont/src/app/app.component.css
+++ b/sysgd-cont/src/app/app.component.css
@@ -10,6 +10,47 @@
   color: #111827;
 }
 
+.promo-banner {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 12px;
+  background: linear-gradient(135deg, #0f172a, #1d4ed8);
+  border-radius: 12px;
+  padding: 14px;
+  color: #ffffff;
+  margin-bottom: 14px;
+}
+
+.promo-banner h2 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.promo-banner p {
+  margin: 4px 0 0;
+  color: #dbeafe;
+  font-size: 13px;
+}
+
+.promo-tag {
+  background: #facc15;
+  color: #111827;
+  border-radius: 999px;
+  padding: 6px 10px;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.promo-banner a {
+  color: #111827;
+  text-decoration: none;
+  background: #ffffff;
+  border-radius: 8px;
+  padding: 8px 12px;
+  font-weight: 600;
+}
+
 .header {
   display: flex;
   justify-content: space-between;
@@ -78,6 +119,21 @@ h1 {
 .auth-card {
   max-width: 560px;
   margin: 30px auto;
+}
+
+.login-promo {
+  margin: 10px 0 14px;
+  padding: 10px;
+  border: 1px solid #bfdbfe;
+  background: #eff6ff;
+  border-radius: 8px;
+  font-size: 14px;
+}
+
+.login-promo a {
+  color: #1d4ed8;
+  font-weight: 600;
+  margin-left: 6px;
 }
 
 .tabs {
@@ -227,5 +283,9 @@ button {
   .header {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .promo-banner {
+    grid-template-columns: 1fr;
   }
 }

--- a/sysgd-cont/src/app/app.component.css
+++ b/sysgd-cont/src/app/app.component.css
@@ -19,7 +19,7 @@
   border-radius: 12px;
   padding: 14px;
   color: #ffffff;
-  margin-bottom: 14px;
+  margin: 0;
 }
 
 .promo-banner h2 {
@@ -49,6 +49,10 @@
   border-radius: 8px;
   padding: 8px 12px;
   font-weight: 600;
+}
+
+.promo-banner-bottom {
+  margin-top: 16px;
 }
 
 .header {
@@ -119,21 +123,6 @@ h1 {
 .auth-card {
   max-width: 560px;
   margin: 30px auto;
-}
-
-.login-promo {
-  margin: 10px 0 14px;
-  padding: 10px;
-  border: 1px solid #bfdbfe;
-  background: #eff6ff;
-  border-radius: 8px;
-  font-size: 14px;
-}
-
-.login-promo a {
-  color: #1d4ed8;
-  font-weight: 600;
-  margin-left: 6px;
 }
 
 .tabs {

--- a/sysgd-cont/src/app/app.component.ts
+++ b/sysgd-cont/src/app/app.component.ts
@@ -19,17 +19,6 @@ import { RegistroSyncService } from './services/registro-sync.service';
   imports: [CommonModule, ReactiveFormsModule, CurrencyPipe],
   template: `
     <main class="container">
-      <section class="promo-banner">
-        <p class="promo-tag">Nuevo en Apklis</p>
-        <div>
-          <h2>Gestor Contable TCP ya está disponible por 50 CUP</h2>
-          <p>Descarga la app SYSGD Cont para llevar tu registro fiscal desde Android, incluso cuando no tengas conexión.</p>
-        </div>
-        <a href="https://apklis.cu/application/cu.lazaroysr96.sysgdcont" target="_blank" rel="noopener noreferrer">
-          Ver en Apklis
-        </a>
-      </section>
-
       <header class="header" *ngIf="sessionReady && currentUser">
         <div>
           <h1>Registro TCP: Ingresos y Gastos</h1>
@@ -50,11 +39,6 @@ import { RegistroSyncService } from './services/registro-sync.service';
       <section class="card auth-card" *ngIf="sessionReady && !currentUser">
         <h2>{{ authMode === 'login' ? 'Iniciar sesión' : 'Crear cuenta' }}</h2>
         <p class="subtitle">Tus datos se guardan localmente y se sincronizan con el servidor.</p>
-        <div class="login-promo">
-          <strong>Promoción:</strong> Obtén la app <b>Gestor Contable TCP</b> en Apklis por solo <b>50 CUP</b>.
-          <a href="https://apklis.cu/application/cu.lazaroysr96.sysgdcont" target="_blank" rel="noopener noreferrer">Descargar ahora</a>
-        </div>
-
         <form [formGroup]="authForm" (ngSubmit)="submitAuth()" class="form-grid">
           <label *ngIf="authMode === 'register'">Nombre completo <input type="text" formControlName="name" /></label>
           <label>Email <input type="email" formControlName="email" /></label>
@@ -212,6 +196,17 @@ import { RegistroSyncService } from './services/registro-sync.service';
         <pre class="dj">{{ djPreview }}</pre>
       </section>
       </ng-container>
+
+      <section class="promo-banner promo-banner-bottom">
+        <p class="promo-tag">Nuevo en Apklis</p>
+        <div>
+          <h2>Gestor Contable TCP ya está disponible por 50 CUP</h2>
+          <p>Descarga la app SYSGD Cont para llevar tu registro fiscal desde Android, incluso cuando no tengas conexión.</p>
+        </div>
+        <a href="https://apklis.cu/application/cu.lazaroysr96.sysgdcont" target="_blank" rel="noopener noreferrer">
+          Ver en Apklis
+        </a>
+      </section>
     </main>
   `,
   styleUrl: './app.component.css'

--- a/sysgd-cont/src/app/app.component.ts
+++ b/sysgd-cont/src/app/app.component.ts
@@ -19,6 +19,17 @@ import { RegistroSyncService } from './services/registro-sync.service';
   imports: [CommonModule, ReactiveFormsModule, CurrencyPipe],
   template: `
     <main class="container">
+      <section class="promo-banner">
+        <p class="promo-tag">Nuevo en Apklis</p>
+        <div>
+          <h2>Gestor Contable TCP ya está disponible por 50 CUP</h2>
+          <p>Descarga la app SYSGD Cont para llevar tu registro fiscal desde Android, incluso cuando no tengas conexión.</p>
+        </div>
+        <a href="https://apklis.cu/application/cu.lazaroysr96.sysgdcont" target="_blank" rel="noopener noreferrer">
+          Ver en Apklis
+        </a>
+      </section>
+
       <header class="header" *ngIf="sessionReady && currentUser">
         <div>
           <h1>Registro TCP: Ingresos y Gastos</h1>
@@ -39,6 +50,10 @@ import { RegistroSyncService } from './services/registro-sync.service';
       <section class="card auth-card" *ngIf="sessionReady && !currentUser">
         <h2>{{ authMode === 'login' ? 'Iniciar sesión' : 'Crear cuenta' }}</h2>
         <p class="subtitle">Tus datos se guardan localmente y se sincronizan con el servidor.</p>
+        <div class="login-promo">
+          <strong>Promoción:</strong> Obtén la app <b>Gestor Contable TCP</b> en Apklis por solo <b>50 CUP</b>.
+          <a href="https://apklis.cu/application/cu.lazaroysr96.sysgdcont" target="_blank" rel="noopener noreferrer">Descargar ahora</a>
+        </div>
 
         <form [formGroup]="authForm" (ngSubmit)="submitAuth()" class="form-grid">
           <label *ngIf="authMode === 'register'">Nombre completo <input type="text" formControlName="name" /></label>


### PR DESCRIPTION
### Motivation
- Promote the newly published Android app “Gestor Contable TCP” on Apklis and make the purchase link visible in the web UI so users can find and download the mobile version. 

### Description
- Added a top promotional banner with headline, description and a link to the Apklis page in `src/app/app.component.ts` that is rendered above the main header. 
- Included a compact promotional block inside the login/register card in `src/app/app.component.ts` so the offer is visible before authentication. 
- Added styles (`.promo-banner`, `.promo-tag`, `.login-promo`) and responsive behavior to `src/app/app.component.css` to style the banner for desktop and mobile.

### Testing
- Built the Angular app with `npm run build` and the build completed successfully. 
- Started the dev server with `npm run start` and verified the app served in watch mode at `http://localhost:4200/`. 
- Captured a headless browser screenshot showing the login view with the new promotional banner at `artifacts/promo-banner-login.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69987fdfc52c83228f0b815cb4f5663c)