### PR TITLE
[cont-pro] Agregar pantalla Estado de Resultado en GCTCP

### DIFF
--- a/client/src/accounting/core/types/accountingTypes.ts
+++ b/client/src/accounting/core/types/accountingTypes.ts
@@ -76,6 +76,35 @@ export type TributoCuentaBase = {
   createdAt: number;
 };
 
+export type WalletTipo = "EFECTIVO" | "BANCO" | "MOVIL" | "MERCANCIA" | "OTRO";
+
+export type Wallet = {
+  id: string;
+  nombre: string;
+  tipo: WalletTipo;
+  saldoInicial: number;
+  moneda: "CUP";
+  activo: boolean;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type WalletMovimientoTipo = "ENTRADA" | "SALIDA" | "TRANSFERENCIA";
+export type WalletReferenciaTipo = "INGRESO" | "GASTO" | "OPERACION_POS" | "MANUAL";
+
+export type WalletMovimiento = {
+  id: string;
+  walletOrigenId: string | null;
+  walletDestinoId: string | null;
+  monto: number;
+  tipo: WalletMovimientoTipo;
+  referenciaId: string | null;
+  referenciaTipo: WalletReferenciaTipo | null;
+  nota: string;
+  fecha: string;
+  createdAt: number;
+};
+
 export type AccountingWorkspaceState = {
   cuentasContables: CuentaContable[];
   ingresoGastoCuentas: IngresoGastoCuenta[];
@@ -83,6 +112,8 @@ export type AccountingWorkspaceState = {
   posIntegrationConfig: PosIntegrationConfig | null;
   tributoConfigs: TributoConfig[];
   tributoCuentaBases: TributoCuentaBase[];
+  wallets?: Wallet[];
+  walletMovimientos?: WalletMovimiento[];
 };
 
 export type Almacen = {

--- a/client/src/gctcp/GC_TCP.tsx
+++ b/client/src/gctcp/GC_TCP.tsx
@@ -20,6 +20,7 @@ import { getViewTitle } from "./navigation";
 import type { GcTcpView, LedgerApiResponse } from "./types";
 import {
 	BackupView,
+	CajaBancoView,
 	CatalogosView,
 	DashboardView,
 	EntriesView,
@@ -270,6 +271,8 @@ const GC_TCP: FC = () => {
 				return <EstadoResultadoView workspace={activeWorkspace} />;
 			case "ventas":
 				return <PointOfSaleView workspace={activeWorkspace} />;
+			case "cajaBanco":
+				return <CajaBancoView workspace={activeWorkspace} />;
 			case "terceros":
 				return <TercerosView workspace={activeWorkspace} />;
 			case "catalogos":

--- a/client/src/gctcp/GC_TCP.tsx
+++ b/client/src/gctcp/GC_TCP.tsx
@@ -23,6 +23,7 @@ import {
 	CatalogosView,
 	DashboardView,
 	EntriesView,
+	EstadoResultadoView,
 	GeneralView,
 	ResumenView,
 	SupportView,
@@ -265,6 +266,8 @@ const GC_TCP: FC = () => {
 				return <TributosView workspace={activeWorkspace} analysis={activeAnalysis} />;
 			case "resumen":
 				return <ResumenView analysis={activeAnalysis} />;
+			case "estadoResultado":
+				return <EstadoResultadoView workspace={activeWorkspace} />;
 			case "ventas":
 				return <PointOfSaleView workspace={activeWorkspace} />;
 			case "terceros":

--- a/client/src/gctcp/navigation.tsx
+++ b/client/src/gctcp/navigation.tsx
@@ -10,6 +10,7 @@ import {
 	Landmark,
 	LayoutDashboard,
 	List,
+	NotebookText,
 	Search,
 	Shield,
 	ShoppingCart,
@@ -32,6 +33,7 @@ export const navigationSections: NavigationSection[] = [
 			{ id: "gastos", label: "Gastos", icon: <TrendingDown /> },
 			{ id: "tributos", label: "Tributos", icon: <Landmark /> },
 			{ id: "resumen", label: "Resumen", icon: <LayoutDashboard /> },
+			{ id: "estadoResultado", label: "Estado de resultado", icon: <NotebookText /> },
 		],
 	},
 	{

--- a/client/src/gctcp/navigation.tsx
+++ b/client/src/gctcp/navigation.tsx
@@ -4,6 +4,7 @@ import {
 	BookOpen,
 	CircleHelp,
 	CreditCard,
+	HandCoins,
 	DatabaseBackup,
 	FileText,
 	Info,
@@ -39,6 +40,7 @@ export const navigationSections: NavigationSection[] = [
 	{
 		title: "Herramientas",
 		items: [
+			{ id: "cajaBanco", label: "Caja y banco", icon: <HandCoins /> },
 			{ id: "ventas", label: "Punto de Venta", icon: <ShoppingCart /> },
 			{ id: "nomencladores", label: "Nomencladores", icon: <List /> },
 			{ id: "terceros", label: "Terceros", icon: <Users /> },

--- a/client/src/gctcp/navigation.tsx
+++ b/client/src/gctcp/navigation.tsx
@@ -33,7 +33,7 @@ export const navigationSections: NavigationSection[] = [
 			{ id: "gastos", label: "Gastos", icon: <TrendingDown /> },
 			{ id: "tributos", label: "Tributos", icon: <Landmark /> },
 			{ id: "resumen", label: "Resumen", icon: <LayoutDashboard /> },
-			{ id: "estadoResultado", label: "Estado de resultado", icon: <NotebookText /> },
+			{ id: "estadoResultado", label: "Libro de ingresos y gastos", icon: <NotebookText /> },
 		],
 	},
 	{

--- a/client/src/gctcp/types.ts
+++ b/client/src/gctcp/types.ts
@@ -14,6 +14,7 @@ export type GcTcpView =
 	| "tributos"
 	| "resumen"
 	| "estadoResultado"
+	| "cajaBanco"
 	| "ventas"
 	| "nomencladores"
 	| "terceros"

--- a/client/src/gctcp/types.ts
+++ b/client/src/gctcp/types.ts
@@ -13,6 +13,7 @@ export type GcTcpView =
 	| "gastos"
 	| "tributos"
 	| "resumen"
+	| "estadoResultado"
 	| "ventas"
 	| "nomencladores"
 	| "terceros"

--- a/client/src/gctcp/views.tsx
+++ b/client/src/gctcp/views.tsx
@@ -390,6 +390,129 @@ export const EstadoResultadoView: FC<{ workspace: CloudWorkspaceEntry }> = ({ wo
 	);
 };
 
+type WalletLedgerRow = {
+	id: string;
+	fecha: string;
+	tipo: string;
+	descripcion: string;
+	origen: string;
+	destino: string;
+	monto: number;
+};
+
+export const CajaBancoView: FC<{ workspace: CloudWorkspaceEntry }> = ({ workspace }) => {
+	const wallets = workspace.accounting.wallets?.filter((wallet) => wallet.activo) ?? [];
+	const walletMovimientos = workspace.accounting.walletMovimientos ?? [];
+	const baseWallets = wallets.length > 0 ? wallets : [
+		{ id: "wallet-efectivo", nombre: "Caja efectivo", tipo: "EFECTIVO", saldoInicial: 0, moneda: "CUP", activo: true, createdAt: 0, updatedAt: 0 },
+		{ id: "wallet-banco", nombre: "Banco", tipo: "BANCO", saldoInicial: 0, moneda: "CUP", activo: true, createdAt: 0, updatedAt: 0 },
+		{ id: "wallet-movil", nombre: "Saldo móvil", tipo: "MOVIL", saldoInicial: 0, moneda: "CUP", activo: true, createdAt: 0, updatedAt: 0 },
+	];
+
+	const valorMercancia = workspace.registro.inventario.stock.reduce((total, stock) => {
+		const precioCostoActivo = workspace.registro.inventario.historialPrecios
+			.filter((precio) => precio.productoId === stock.productoId && precio.tipoPrecio === "COMPRA" && precio.activo)
+			.sort((a, b) => b.fechaDesde.localeCompare(a.fechaDesde))[0];
+		const precioCosto = precioCostoActivo?.precio ?? 0;
+		return total + (stock.stockDisponible * precioCosto);
+	}, 0);
+
+	const walletSaldos = baseWallets.map((wallet) => {
+		const entradas = walletMovimientos
+			.filter((mov) => mov.walletDestinoId === wallet.id)
+			.reduce((total, mov) => total + mov.monto, 0);
+		const salidas = walletMovimientos
+			.filter((mov) => mov.walletOrigenId === wallet.id)
+			.reduce((total, mov) => total + mov.monto, 0);
+		return { ...wallet, saldoActual: wallet.saldoInicial + entradas - salidas };
+	});
+
+	const totalLiquido = walletSaldos
+		.filter((wallet) => wallet.tipo !== "MERCANCIA")
+		.reduce((total, wallet) => total + wallet.saldoActual, 0);
+
+	const walletNameById = Object.fromEntries(walletSaldos.map((wallet) => [wallet.id, wallet.nombre]));
+	const movimientos: WalletLedgerRow[] = walletMovimientos
+		.map((mov) => ({
+			id: mov.id,
+			fecha: mov.fecha,
+			tipo: mov.tipo,
+			descripcion: mov.nota || mov.referenciaTipo || "Movimiento",
+			origen: mov.walletOrigenId ? walletNameById[mov.walletOrigenId] ?? "Wallet desconocida" : "Entrada externa",
+			destino: mov.walletDestinoId ? walletNameById[mov.walletDestinoId] ?? "Wallet desconocida" : "Salida externa",
+			monto: mov.monto,
+		}))
+		.sort((a, b) => b.fecha.localeCompare(a.fecha));
+
+	return (
+		<div className="space-y-4">
+			<div className="flex flex-wrap items-center justify-between gap-3">
+				<div>
+					<h3 className="text-base font-semibold">Caja y banco</h3>
+					<p className="text-sm text-slate-500 dark:text-slate-400">Vista informativa del dinero por contenedor.</p>
+				</div>
+				<Button variant="outline" size="sm" disabled>
+					Registrar movimiento manual (próximamente)
+				</Button>
+			</div>
+			<div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+				{walletSaldos.map((wallet) => (
+					<Card key={wallet.id} className="rounded-lg shadow-sm">
+						<CardContent className="p-4">
+							<p className="text-xs uppercase text-slate-500 dark:text-slate-400">{wallet.nombre}</p>
+							<p className={cn("mt-2 text-xl font-semibold", wallet.saldoActual >= 0 ? "text-emerald-700 dark:text-emerald-300" : "text-rose-700 dark:text-rose-300")}>
+								{formatMoney(wallet.saldoActual)} CUP
+							</p>
+							<p className="text-xs text-slate-500 dark:text-slate-400">{wallet.tipo}</p>
+						</CardContent>
+					</Card>
+				))}
+				<Card className="rounded-lg border-dashed shadow-sm">
+					<CardContent className="p-4">
+						<p className="text-xs uppercase text-slate-500 dark:text-slate-400">Mercancía (costo)</p>
+						<p className="mt-2 text-xl font-semibold text-sky-700 dark:text-sky-300">{formatMoney(valorMercancia)} CUP</p>
+						<p className="text-xs text-slate-500 dark:text-slate-400">Calculada automáticamente desde inventario.</p>
+					</CardContent>
+				</Card>
+			</div>
+			<Card className="rounded-lg shadow-sm">
+				<CardContent className="p-4">
+					<p className="text-sm text-slate-500 dark:text-slate-400">Total líquido (sin mercancía)</p>
+					<p className={cn("text-2xl font-semibold", totalLiquido >= 0 ? "text-emerald-700 dark:text-emerald-300" : "text-rose-700 dark:text-rose-300")}>
+						{formatMoney(totalLiquido)} CUP
+					</p>
+				</CardContent>
+			</Card>
+			<Card className="rounded-lg shadow-sm">
+				<CardHeader className="p-4">
+					<CardTitle className="text-base">Movimientos de wallets</CardTitle>
+				</CardHeader>
+				<CardContent className="p-4 pt-0">
+					<div className="overflow-x-auto">
+						<table className="w-full min-w-[860px] text-sm">
+							<thead>
+								<tr className="border-b border-slate-200 text-left text-xs uppercase text-slate-500 dark:border-slate-800 dark:text-slate-400">
+									<th className="py-3 pr-4">Fecha</th><th className="py-3 pr-4">Tipo</th><th className="py-3 pr-4">Origen</th><th className="py-3 pr-4">Destino</th><th className="py-3 pr-4">Descripción</th><th className="py-3 pr-4 text-right">Monto</th>
+								</tr>
+							</thead>
+							<tbody>
+								{movimientos.map((mov) => (
+									<tr key={mov.id} className="border-b border-slate-100 dark:border-slate-800/80">
+										<td className="py-3 pr-4">{mov.fecha}</td><td className="py-3 pr-4">{mov.tipo}</td><td className="py-3 pr-4">{mov.origen}</td><td className="py-3 pr-4">{mov.destino}</td><td className="py-3 pr-4">{mov.descripcion}</td><td className="py-3 pr-4 text-right font-semibold">{formatMoney(mov.monto)}</td>
+									</tr>
+								))}
+								{movimientos.length === 0 && (
+									<tr><td colSpan={6} className="py-8 text-center text-slate-500 dark:text-slate-400">Sin movimientos registrados en wallets.</td></tr>
+								)}
+							</tbody>
+						</table>
+					</div>
+				</CardContent>
+			</Card>
+		</div>
+	);
+};
+
 export const TributosView: FC<{ workspace: CloudWorkspaceEntry; analysis: WorkspaceAnalysis }> = ({ workspace, analysis }) => (
 	<div className="space-y-4">
 		<div className="grid gap-4 md:grid-cols-3">

--- a/client/src/gctcp/views.tsx
+++ b/client/src/gctcp/views.tsx
@@ -204,9 +204,21 @@ type StatementRow = {
 };
 
 export const EstadoResultadoView: FC<{ workspace: CloudWorkspaceEntry }> = ({ workspace }) => {
+	const notasPorId = Object.fromEntries(
+		workspace.accounting.ingresoGastoNotas.map((nota) => [nota.ingresoGastoId, nota.nota]),
+	);
+	const cuentaIdPorId = Object.fromEntries(
+		workspace.accounting.ingresoGastoCuentas.map((cuentaRelacion) => [
+			cuentaRelacion.ingresoGastoId,
+			cuentaRelacion.cuentaId,
+		]),
+	);
+	const cuentasPorId = Object.fromEntries(
+		workspace.accounting.cuentasContables.map((cuentaContable) => [cuentaContable.id, cuentaContable.nombre]),
+	);
+
 	const statementRows: StatementRow[] = MONTH_CODES.flatMap((month) => {
 		const ingresos = activeRows(getRows(workspace.registro, "ingresos", month)).map((row) => {
-			const rowWithMeta = row as typeof row & { detalle?: string; cuenta?: string };
 			return {
 				id: `${month}-ingreso-${row.id}`,
 				month,
@@ -214,12 +226,11 @@ export const EstadoResultadoView: FC<{ workspace: CloudWorkspaceEntry }> = ({ wo
 				type: "Ingreso" as const,
 				income: parseAmount(row.importe),
 				expense: 0,
-				detail: rowWithMeta.detalle || "-",
-				account: rowWithMeta.cuenta || "-",
+				detail: notasPorId[row.id] ?? "-",
+				account: cuentasPorId[cuentaIdPorId[row.id]] ?? "-",
 			};
 		});
 		const gastos = activeRows(getRows(workspace.registro, "gastos", month)).map((row) => {
-			const rowWithMeta = row as typeof row & { detalle?: string; cuenta?: string };
 			return {
 				id: `${month}-gasto-${row.id}`,
 				month,
@@ -227,8 +238,8 @@ export const EstadoResultadoView: FC<{ workspace: CloudWorkspaceEntry }> = ({ wo
 				type: "Gasto" as const,
 				income: 0,
 				expense: parseAmount(row.importe),
-				detail: rowWithMeta.detalle || "-",
-				account: rowWithMeta.cuenta || "-",
+				detail: notasPorId[row.id] ?? "-",
+				account: cuentasPorId[cuentaIdPorId[row.id]] ?? "-",
 			};
 		});
 		return [...ingresos, ...gastos];

--- a/client/src/gctcp/views.tsx
+++ b/client/src/gctcp/views.tsx
@@ -192,6 +192,109 @@ export const EntriesView: FC<{ workspace: CloudWorkspaceEntry; type: "ingresos" 
 	);
 };
 
+type StatementRow = {
+	id: string;
+	month: string;
+	dateLabel: string;
+	type: "Ingreso" | "Gasto";
+	income: number;
+	expense: number;
+	detail: string;
+	account: string;
+};
+
+export const EstadoResultadoView: FC<{ workspace: CloudWorkspaceEntry }> = ({ workspace }) => {
+	const statementRows: StatementRow[] = MONTH_CODES.flatMap((month) => {
+		const ingresos = activeRows(getRows(workspace.registro, "ingresos", month)).map((row) => {
+			const rowWithMeta = row as typeof row & { detalle?: string; cuenta?: string };
+			return {
+				id: `${month}-ingreso-${row.id}`,
+				month,
+				dateLabel: `${row.dia || "--"}/${month}`,
+				type: "Ingreso" as const,
+				income: parseAmount(row.importe),
+				expense: 0,
+				detail: rowWithMeta.detalle || "-",
+				account: rowWithMeta.cuenta || "-",
+			};
+		});
+		const gastos = activeRows(getRows(workspace.registro, "gastos", month)).map((row) => {
+			const rowWithMeta = row as typeof row & { detalle?: string; cuenta?: string };
+			return {
+				id: `${month}-gasto-${row.id}`,
+				month,
+				dateLabel: `${row.dia || "--"}/${month}`,
+				type: "Gasto" as const,
+				income: 0,
+				expense: parseAmount(row.importe),
+				detail: rowWithMeta.detalle || "-",
+				account: rowWithMeta.cuenta || "-",
+			};
+		});
+		return [...ingresos, ...gastos];
+	}).sort((a, b) => a.month.localeCompare(b.month) || a.dateLabel.localeCompare(b.dateLabel));
+
+	return (
+		<Card className="rounded-lg shadow-sm">
+			<CardHeader className="flex-row items-center justify-between gap-3 p-4">
+				<CardTitle className="text-base">Estado de resultado (ingresos y gastos)</CardTitle>
+				<Badge variant="outline">{workspace.name}</Badge>
+			</CardHeader>
+			<CardContent className="space-y-4 p-4 pt-0">
+				<div className="grid gap-3 sm:grid-cols-3">
+					<div className="rounded-md bg-emerald-50 p-3 text-sm dark:bg-emerald-500/10">
+						<p className="text-slate-500 dark:text-slate-300">Ingresos</p>
+						<p className="font-semibold text-emerald-700 dark:text-emerald-300">{formatMoney(statementRows.reduce((t, r) => t + r.income, 0))}</p>
+					</div>
+					<div className="rounded-md bg-rose-50 p-3 text-sm dark:bg-rose-500/10">
+						<p className="text-slate-500 dark:text-slate-300">Gastos</p>
+						<p className="font-semibold text-rose-700 dark:text-rose-300">{formatMoney(statementRows.reduce((t, r) => t + r.expense, 0))}</p>
+					</div>
+					<div className="rounded-md bg-slate-100 p-3 text-sm dark:bg-slate-800">
+						<p className="text-slate-500 dark:text-slate-300">Resultado</p>
+						<p className="font-semibold text-slate-900 dark:text-slate-50">{formatMoney(statementRows.reduce((t, r) => t + r.income - r.expense, 0))}</p>
+					</div>
+				</div>
+				<div className="overflow-x-auto">
+					<table className="w-full min-w-[940px] text-sm">
+						<thead>
+							<tr className="border-b border-slate-200 text-left text-xs uppercase text-slate-500 dark:border-slate-800 dark:text-slate-400">
+								<th className="py-3 pr-4">Mes</th>
+								<th className="py-3 pr-4">Fecha</th>
+								<th className="py-3 pr-4">Tipo</th>
+								<th className="py-3 pr-4 text-right">Ingreso</th>
+								<th className="py-3 pr-4 text-right">Gasto</th>
+								<th className="py-3 pr-4">Detalle</th>
+								<th className="py-3 pr-4">Cuenta afectada</th>
+							</tr>
+						</thead>
+						<tbody>
+							{statementRows.map((row) => (
+								<tr key={row.id} className="border-b border-slate-100 dark:border-slate-800/80">
+									<td className="py-3 pr-4 font-medium text-slate-950 dark:text-slate-50">{row.month}</td>
+									<td className="py-3 pr-4 text-slate-600 dark:text-slate-300">{row.dateLabel}</td>
+									<td className={cn("py-3 pr-4 font-medium", row.type === "Ingreso" ? "text-emerald-700 dark:text-emerald-300" : "text-rose-700 dark:text-rose-300")}>{row.type}</td>
+									<td className="py-3 pr-4 text-right text-emerald-700 dark:text-emerald-300">{row.income > 0 ? formatMoney(row.income) : "-"}</td>
+									<td className="py-3 pr-4 text-right text-rose-700 dark:text-rose-300">{row.expense > 0 ? formatMoney(row.expense) : "-"}</td>
+									<td className="py-3 pr-4 text-slate-600 dark:text-slate-300">{row.detail}</td>
+									<td className="py-3 pr-4 text-slate-600 dark:text-slate-300">{row.account}</td>
+								</tr>
+							))}
+							{statementRows.length === 0 && (
+								<tr>
+									<td colSpan={7} className="py-8 text-center text-slate-500 dark:text-slate-400">
+										No hay movimientos registrados para mostrar.
+									</td>
+								</tr>
+							)}
+						</tbody>
+					</table>
+				</div>
+			</CardContent>
+		</Card>
+	);
+};
+
 export const TributosView: FC<{ workspace: CloudWorkspaceEntry; analysis: WorkspaceAnalysis }> = ({ workspace, analysis }) => (
 	<div className="space-y-4">
 		<div className="grid gap-4 md:grid-cols-3">

--- a/client/src/gctcp/views.tsx
+++ b/client/src/gctcp/views.tsx
@@ -251,10 +251,22 @@ export const EstadoResultadoView: FC<{ workspace: CloudWorkspaceEntry }> = ({ wo
 		});
 		return [...ingresos, ...gastos];
 	}).sort((a, b) => a.month.localeCompare(b.month) || a.dateLabel.localeCompare(b.dateLabel));
+	const totalIngresos = statementRows.reduce((total, row) => total + row.income, 0);
+	const totalGastos = statementRows.reduce((total, row) => total + row.expense, 0);
+	const resultado = totalIngresos - totalGastos;
+	const resultadoLabel = resultado >= 0 ? "POSITIVO" : "NEGATIVO";
 
 	const handleDownloadExcel = () => {
 		const workbook = XLSX.utils.book_new();
-		const rows = statementRows.map((row) => ({
+		const rows: Array<{
+			Mes: string;
+			Fecha: string;
+			Tipo: string;
+			Ingreso: number | "";
+			Gasto: number | "";
+			Detalle: string;
+			"Cuenta afectada": string;
+		}> = statementRows.map((row) => ({
 			Mes: row.month,
 			Fecha: row.dateLabel,
 			Tipo: row.type,
@@ -263,6 +275,12 @@ export const EstadoResultadoView: FC<{ workspace: CloudWorkspaceEntry }> = ({ wo
 			Detalle: row.detail,
 			"Cuenta afectada": row.account,
 		}));
+		rows.push(
+			{ Mes: "", Fecha: "", Tipo: "", Ingreso: "", Gasto: "", Detalle: "", "Cuenta afectada": "" },
+			{ Mes: "TOTAL INGRESOS", Fecha: "", Tipo: "", Ingreso: totalIngresos, Gasto: "", Detalle: "", "Cuenta afectada": "" },
+			{ Mes: "TOTAL GASTOS", Fecha: "", Tipo: "", Ingreso: "", Gasto: totalGastos, Detalle: "", "Cuenta afectada": "" },
+			{ Mes: `RESULTADO ${resultadoLabel}`, Fecha: "", Tipo: "", Ingreso: resultado, Gasto: "", Detalle: "", "Cuenta afectada": "" },
+		);
 		const worksheet = XLSX.utils.json_to_sheet(rows);
 		XLSX.utils.book_append_sheet(workbook, worksheet, "EstadoResultado");
 		const fileName = `estado-resultado-${workspace.name.replace(/\s+/g, "-").toLowerCase()}-${new Date().toISOString().slice(0, 10)}.xlsx`;
@@ -280,7 +298,7 @@ export const EstadoResultadoView: FC<{ workspace: CloudWorkspaceEntry }> = ({ wo
 				row.expense > 0 ? formatMoney(row.expense) : "-",
 				row.detail,
 				row.account,
-			]),
+				]),
 		];
 		const docDefinition: TDocumentDefinitions = {
 			content: [
@@ -293,6 +311,12 @@ export const EstadoResultadoView: FC<{ workspace: CloudWorkspaceEntry }> = ({ wo
 						body,
 					},
 					layout: "lightHorizontalLines",
+				},
+				{
+					text: `Resultado final: ${formatMoney(resultado)} (${resultadoLabel})`,
+					bold: true,
+					color: resultado >= 0 ? "#047857" : "#be123c",
+					margin: [0, 8, 0, 0],
 				},
 			],
 			styles: {
@@ -319,19 +343,21 @@ export const EstadoResultadoView: FC<{ workspace: CloudWorkspaceEntry }> = ({ wo
 			</CardHeader>
 			<CardContent className="space-y-4 p-4 pt-0">
 				<div className="grid gap-3 sm:grid-cols-3">
-					<div className="rounded-md bg-emerald-50 p-3 text-sm dark:bg-emerald-500/10">
-						<p className="text-slate-500 dark:text-slate-300">Ingresos</p>
-						<p className="font-semibold text-emerald-700 dark:text-emerald-300">{formatMoney(statementRows.reduce((t, r) => t + r.income, 0))}</p>
+						<div className="rounded-md bg-emerald-50 p-3 text-sm dark:bg-emerald-500/10">
+							<p className="text-slate-500 dark:text-slate-300">Ingresos</p>
+							<p className="font-semibold text-emerald-700 dark:text-emerald-300">{formatMoney(totalIngresos)}</p>
+						</div>
+						<div className="rounded-md bg-rose-50 p-3 text-sm dark:bg-rose-500/10">
+							<p className="text-slate-500 dark:text-slate-300">Gastos</p>
+							<p className="font-semibold text-rose-700 dark:text-rose-300">{formatMoney(totalGastos)}</p>
+						</div>
+						<div className="rounded-md bg-slate-100 p-3 text-sm dark:bg-slate-800">
+							<p className="text-slate-500 dark:text-slate-300">Resultado</p>
+							<p className={cn("font-semibold", resultado >= 0 ? "text-emerald-700 dark:text-emerald-300" : "text-rose-700 dark:text-rose-300")}>
+								{formatMoney(resultado)} ({resultadoLabel})
+							</p>
+						</div>
 					</div>
-					<div className="rounded-md bg-rose-50 p-3 text-sm dark:bg-rose-500/10">
-						<p className="text-slate-500 dark:text-slate-300">Gastos</p>
-						<p className="font-semibold text-rose-700 dark:text-rose-300">{formatMoney(statementRows.reduce((t, r) => t + r.expense, 0))}</p>
-					</div>
-					<div className="rounded-md bg-slate-100 p-3 text-sm dark:bg-slate-800">
-						<p className="text-slate-500 dark:text-slate-300">Resultado</p>
-						<p className="font-semibold text-slate-900 dark:text-slate-50">{formatMoney(statementRows.reduce((t, r) => t + r.income - r.expense, 0))}</p>
-					</div>
-				</div>
 				<div className="overflow-x-auto">
 					<table className="w-full min-w-[940px] text-sm">
 						<thead>

--- a/client/src/gctcp/views.tsx
+++ b/client/src/gctcp/views.tsx
@@ -20,6 +20,10 @@ import {
 	Users,
 	WalletCards,
 } from "lucide-react";
+import pdfMake from "pdfmake/build/pdfmake";
+import pdfFonts from "pdfmake/build/vfs_fonts";
+import type { TDocumentDefinitions } from "pdfmake/interfaces";
+import * as XLSX from "xlsx";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -40,6 +44,9 @@ import {
 import { EmptyState, MetricCard, WorkspaceSelector } from "./components";
 import { ProductCatalogPanel } from "./products/ProductCatalogPanel";
 import type { GcTcpView, WorkspaceAnalysis } from "./types";
+
+const pdfMakeWithVfs = pdfMake as unknown as { vfs?: typeof pdfFonts.vfs };
+pdfMakeWithVfs.vfs = pdfFonts.vfs;
 
 export const DashboardView: FC<{
 	analyses: WorkspaceAnalysis[];
@@ -245,11 +252,70 @@ export const EstadoResultadoView: FC<{ workspace: CloudWorkspaceEntry }> = ({ wo
 		return [...ingresos, ...gastos];
 	}).sort((a, b) => a.month.localeCompare(b.month) || a.dateLabel.localeCompare(b.dateLabel));
 
+	const handleDownloadExcel = () => {
+		const workbook = XLSX.utils.book_new();
+		const rows = statementRows.map((row) => ({
+			Mes: row.month,
+			Fecha: row.dateLabel,
+			Tipo: row.type,
+			Ingreso: row.income,
+			Gasto: row.expense,
+			Detalle: row.detail,
+			"Cuenta afectada": row.account,
+		}));
+		const worksheet = XLSX.utils.json_to_sheet(rows);
+		XLSX.utils.book_append_sheet(workbook, worksheet, "EstadoResultado");
+		const fileName = `estado-resultado-${workspace.name.replace(/\s+/g, "-").toLowerCase()}-${new Date().toISOString().slice(0, 10)}.xlsx`;
+		XLSX.writeFile(workbook, fileName);
+	};
+
+	const handleDownloadPdf = () => {
+		const body = [
+			["Mes", "Fecha", "Tipo", "Ingreso", "Gasto", "Detalle", "Cuenta afectada"],
+			...statementRows.map((row) => [
+				row.month,
+				row.dateLabel,
+				row.type,
+				row.income > 0 ? formatMoney(row.income) : "-",
+				row.expense > 0 ? formatMoney(row.expense) : "-",
+				row.detail,
+				row.account,
+			]),
+		];
+		const docDefinition: TDocumentDefinitions = {
+			content: [
+				{ text: "Estado de resultado", style: "title" },
+				{ text: workspace.name, margin: [0, 0, 0, 8] },
+				{
+					table: {
+						headerRows: 1,
+						widths: ["auto", "auto", "auto", "auto", "auto", "*", "*"],
+						body,
+					},
+					layout: "lightHorizontalLines",
+				},
+			],
+			styles: {
+				title: { fontSize: 14, bold: true },
+			},
+			defaultStyle: { fontSize: 9 },
+		};
+		pdfMake.createPdf(docDefinition).download(
+			`estado-resultado-${workspace.name.replace(/\s+/g, "-").toLowerCase()}-${new Date().toISOString().slice(0, 10)}.pdf`,
+		);
+	};
+
 	return (
 		<Card className="rounded-lg shadow-sm">
 			<CardHeader className="flex-row items-center justify-between gap-3 p-4">
-				<CardTitle className="text-base">Estado de resultado (ingresos y gastos)</CardTitle>
-				<Badge variant="outline">{workspace.name}</Badge>
+				<div>
+					<CardTitle className="text-base">Estado de resultado (ingresos y gastos)</CardTitle>
+					<Badge variant="outline" className="mt-2">{workspace.name}</Badge>
+				</div>
+				<div className="flex gap-2">
+					<Button variant="outline" size="sm" onClick={handleDownloadExcel}>Descargar Excel</Button>
+					<Button variant="outline" size="sm" onClick={handleDownloadPdf}>Descargar PDF</Button>
+				</div>
 			</CardHeader>
 			<CardContent className="space-y-4 p-4 pt-0">
 				<div className="grid gap-3 sm:grid-cols-3">

--- a/client/src/gctcp/views.tsx
+++ b/client/src/gctcp/views.tsx
@@ -202,8 +202,7 @@ export const EntriesView: FC<{ workspace: CloudWorkspaceEntry; type: "ingresos" 
 type StatementRow = {
 	id: string;
 	month: string;
-	dateLabel: string;
-	type: "Ingreso" | "Gasto";
+	day: string;
 	income: number;
 	expense: number;
 	detail: string;
@@ -227,30 +226,28 @@ export const EstadoResultadoView: FC<{ workspace: CloudWorkspaceEntry }> = ({ wo
 	const statementRows: StatementRow[] = MONTH_CODES.flatMap((month) => {
 		const ingresos = activeRows(getRows(workspace.registro, "ingresos", month)).map((row) => {
 			return {
-				id: `${month}-ingreso-${row.id}`,
-				month,
-				dateLabel: `${row.dia || "--"}/${month}`,
-				type: "Ingreso" as const,
-				income: parseAmount(row.importe),
-				expense: 0,
-				detail: notasPorId[row.id] ?? "-",
+					id: `${month}-ingreso-${row.id}`,
+					month,
+					day: row.dia || "--",
+					income: parseAmount(row.importe),
+					expense: 0,
+					detail: notasPorId[row.id] ?? "-",
 				account: cuentasPorId[cuentaIdPorId[row.id]] ?? "-",
 			};
 		});
 		const gastos = activeRows(getRows(workspace.registro, "gastos", month)).map((row) => {
 			return {
-				id: `${month}-gasto-${row.id}`,
-				month,
-				dateLabel: `${row.dia || "--"}/${month}`,
-				type: "Gasto" as const,
-				income: 0,
-				expense: parseAmount(row.importe),
-				detail: notasPorId[row.id] ?? "-",
+					id: `${month}-gasto-${row.id}`,
+					month,
+					day: row.dia || "--",
+					income: 0,
+					expense: parseAmount(row.importe),
+					detail: notasPorId[row.id] ?? "-",
 				account: cuentasPorId[cuentaIdPorId[row.id]] ?? "-",
 			};
 		});
 		return [...ingresos, ...gastos];
-	}).sort((a, b) => a.month.localeCompare(b.month) || a.dateLabel.localeCompare(b.dateLabel));
+		}).sort((a, b) => a.month.localeCompare(b.month) || a.day.localeCompare(b.day));
 	const totalIngresos = statementRows.reduce((total, row) => total + row.income, 0);
 	const totalGastos = statementRows.reduce((total, row) => total + row.expense, 0);
 	const resultado = totalIngresos - totalGastos;
@@ -258,56 +255,53 @@ export const EstadoResultadoView: FC<{ workspace: CloudWorkspaceEntry }> = ({ wo
 
 	const handleDownloadExcel = () => {
 		const workbook = XLSX.utils.book_new();
-		const rows: Array<{
-			Mes: string;
-			Fecha: string;
-			Tipo: string;
-			Ingreso: number | "";
-			Gasto: number | "";
-			Detalle: string;
+			const rows: Array<{
+				Mes: string;
+				Dia: string;
+				Ingreso: number | "";
+				Gasto: number | "";
+				Detalle: string;
 			"Cuenta afectada": string;
-		}> = statementRows.map((row) => ({
-			Mes: row.month,
-			Fecha: row.dateLabel,
-			Tipo: row.type,
-			Ingreso: row.income,
-			Gasto: row.expense,
+			}> = statementRows.map((row) => ({
+				Mes: row.month,
+				Dia: row.day,
+				Ingreso: row.income,
+				Gasto: row.expense,
 			Detalle: row.detail,
 			"Cuenta afectada": row.account,
 		}));
-		rows.push(
-			{ Mes: "", Fecha: "", Tipo: "", Ingreso: "", Gasto: "", Detalle: "", "Cuenta afectada": "" },
-			{ Mes: "TOTAL INGRESOS", Fecha: "", Tipo: "", Ingreso: totalIngresos, Gasto: "", Detalle: "", "Cuenta afectada": "" },
-			{ Mes: "TOTAL GASTOS", Fecha: "", Tipo: "", Ingreso: "", Gasto: totalGastos, Detalle: "", "Cuenta afectada": "" },
-			{ Mes: `RESULTADO ${resultadoLabel}`, Fecha: "", Tipo: "", Ingreso: resultado, Gasto: "", Detalle: "", "Cuenta afectada": "" },
-		);
+			rows.push(
+				{ Mes: "", Dia: "", Ingreso: "", Gasto: "", Detalle: "", "Cuenta afectada": "" },
+				{ Mes: "TOTAL INGRESOS", Dia: "", Ingreso: totalIngresos, Gasto: "", Detalle: "", "Cuenta afectada": "" },
+				{ Mes: "TOTAL GASTOS", Dia: "", Ingreso: "", Gasto: totalGastos, Detalle: "", "Cuenta afectada": "" },
+				{ Mes: `RESULTADO ${resultadoLabel}`, Dia: "", Ingreso: resultado, Gasto: "", Detalle: "", "Cuenta afectada": "" },
+			);
 		const worksheet = XLSX.utils.json_to_sheet(rows);
 		XLSX.utils.book_append_sheet(workbook, worksheet, "EstadoResultado");
-		const fileName = `estado-resultado-${workspace.name.replace(/\s+/g, "-").toLowerCase()}-${new Date().toISOString().slice(0, 10)}.xlsx`;
+			const fileName = `libro-ingresos-gastos-${workspace.name.replace(/\s+/g, "-").toLowerCase()}-${new Date().toISOString().slice(0, 10)}.xlsx`;
 		XLSX.writeFile(workbook, fileName);
 	};
 
 	const handleDownloadPdf = () => {
 		const body = [
-			["Mes", "Fecha", "Tipo", "Ingreso", "Gasto", "Detalle", "Cuenta afectada"],
-			...statementRows.map((row) => [
-				row.month,
-				row.dateLabel,
-				row.type,
-				row.income > 0 ? formatMoney(row.income) : "-",
-				row.expense > 0 ? formatMoney(row.expense) : "-",
-				row.detail,
+				["Mes", "Día", "Ingreso", "Gasto", "Detalle", "Cuenta afectada"],
+				...statementRows.map((row) => [
+					row.month,
+					row.day,
+					row.income > 0 ? formatMoney(row.income) : "-",
+					row.expense > 0 ? formatMoney(row.expense) : "-",
+					row.detail,
 				row.account,
 				]),
 		];
 		const docDefinition: TDocumentDefinitions = {
 			content: [
-				{ text: "Estado de resultado", style: "title" },
+				{ text: "Libro de ingresos y gastos", style: "title" },
 				{ text: workspace.name, margin: [0, 0, 0, 8] },
 				{
 					table: {
 						headerRows: 1,
-						widths: ["auto", "auto", "auto", "auto", "auto", "*", "*"],
+							widths: ["auto", "auto", "auto", "auto", "*", "*"],
 						body,
 					},
 					layout: "lightHorizontalLines",
@@ -324,16 +318,16 @@ export const EstadoResultadoView: FC<{ workspace: CloudWorkspaceEntry }> = ({ wo
 			},
 			defaultStyle: { fontSize: 9 },
 		};
-		pdfMake.createPdf(docDefinition).download(
-			`estado-resultado-${workspace.name.replace(/\s+/g, "-").toLowerCase()}-${new Date().toISOString().slice(0, 10)}.pdf`,
-		);
-	};
+			pdfMake.createPdf(docDefinition).download(
+				`libro-ingresos-gastos-${workspace.name.replace(/\s+/g, "-").toLowerCase()}-${new Date().toISOString().slice(0, 10)}.pdf`,
+			);
+		};
 
 	return (
 		<Card className="rounded-lg shadow-sm">
 			<CardHeader className="flex-row items-center justify-between gap-3 p-4">
 				<div>
-					<CardTitle className="text-base">Estado de resultado (ingresos y gastos)</CardTitle>
+						<CardTitle className="text-base">Libro de ingresos y gastos</CardTitle>
 					<Badge variant="outline" className="mt-2">{workspace.name}</Badge>
 				</div>
 				<div className="flex gap-2">
@@ -363,9 +357,8 @@ export const EstadoResultadoView: FC<{ workspace: CloudWorkspaceEntry }> = ({ wo
 						<thead>
 							<tr className="border-b border-slate-200 text-left text-xs uppercase text-slate-500 dark:border-slate-800 dark:text-slate-400">
 								<th className="py-3 pr-4">Mes</th>
-								<th className="py-3 pr-4">Fecha</th>
-								<th className="py-3 pr-4">Tipo</th>
-								<th className="py-3 pr-4 text-right">Ingreso</th>
+									<th className="py-3 pr-4">Día</th>
+									<th className="py-3 pr-4 text-right">Ingreso</th>
 								<th className="py-3 pr-4 text-right">Gasto</th>
 								<th className="py-3 pr-4">Detalle</th>
 								<th className="py-3 pr-4">Cuenta afectada</th>
@@ -375,8 +368,7 @@ export const EstadoResultadoView: FC<{ workspace: CloudWorkspaceEntry }> = ({ wo
 							{statementRows.map((row) => (
 								<tr key={row.id} className="border-b border-slate-100 dark:border-slate-800/80">
 									<td className="py-3 pr-4 font-medium text-slate-950 dark:text-slate-50">{row.month}</td>
-									<td className="py-3 pr-4 text-slate-600 dark:text-slate-300">{row.dateLabel}</td>
-									<td className={cn("py-3 pr-4 font-medium", row.type === "Ingreso" ? "text-emerald-700 dark:text-emerald-300" : "text-rose-700 dark:text-rose-300")}>{row.type}</td>
+										<td className="py-3 pr-4 text-slate-600 dark:text-slate-300">{row.day}</td>
 									<td className="py-3 pr-4 text-right text-emerald-700 dark:text-emerald-300">{row.income > 0 ? formatMoney(row.income) : "-"}</td>
 									<td className="py-3 pr-4 text-right text-rose-700 dark:text-rose-300">{row.expense > 0 ? formatMoney(row.expense) : "-"}</td>
 									<td className="py-3 pr-4 text-slate-600 dark:text-slate-300">{row.detail}</td>
@@ -385,7 +377,7 @@ export const EstadoResultadoView: FC<{ workspace: CloudWorkspaceEntry }> = ({ wo
 							))}
 							{statementRows.length === 0 && (
 								<tr>
-									<td colSpan={7} className="py-8 text-center text-slate-500 dark:text-slate-400">
+										<td colSpan={6} className="py-8 text-center text-slate-500 dark:text-slate-400">
 										No hay movimientos registrados para mostrar.
 									</td>
 								</tr>


### PR DESCRIPTION
### Motivation

- Proveer al módulo GCTCP del cliente principal una pantalla tipo estado de resultado que consolide ingresos y gastos en una vista similar a libro diario. 

### Description

- Se añadió el nuevo view id `estadoResultado` en `client/src/gctcp/types.ts` para exponer la vista en el enrutado interno. 
- Se incorporó la opción en el menú lateral en `client/src/gctcp/navigation.tsx` con su ícono `NotebookText` y etiqueta `Estado de resultado`. 
- Se implementó `EstadoResultadoView` en `client/src/gctcp/views.tsx` que construye filas combinadas de `ingresos` y `gastos` por mes y las muestra en una tabla con columnas `Mes`, `Fecha`, `Tipo`, `Ingreso`, `Gasto`, `Detalle` y `Cuenta afectada`, además de tarjetas resumen (Ingresos / Gastos / Resultado). 
- Se integró la nueva vista en el render principal en `client/src/gctcp/GC_TCP.tsx` para que se muestre al seleccionar `estadoResultado` desde la barra lateral. 

### Testing

- Ejecutado `npm run build` en `client` y la compilación completó con éxito. 
- Ejecutado `npm run lint` en `client` y falló por errores preexistentes en múltiples archivos fuera del alcance de estos cambios; el fallo no está relacionado con la nueva vista.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f61ec0948c83278ecb90a456e9b807)