### PR TITLE
fix: render product avatars in linked stock selector

### DIFF
--- a/accounting/android/app/src/main/java/cu/lazaroysr96/sysgdcont/ui/main/screens/InventarioScreen.kt
+++ b/accounting/android/app/src/main/java/cu/lazaroysr96/sysgdcont/ui/main/screens/InventarioScreen.kt
@@ -1004,22 +1004,87 @@ data class VinculadoTemp(val productoId: String, val ratio: Double)
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun VinculadoItemRow(vinculado: VinculadoTemp, productosCompra: List<ProductoCompra>, productosVinculados: List<String>, onProductoCambiado: (String) -> Unit, onRatioCambiado: (Double) -> Unit, onEliminar: () -> Unit) {
+private fun VinculadoItemRow(
+    vinculado: VinculadoTemp,
+    productosCompra: List<ProductoCompra>,
+    productosVinculados: List<String>,
+    onProductoCambiado: (String) -> Unit,
+    onRatioCambiado: (Double) -> Unit,
+    onEliminar: () -> Unit
+) {
     var dropdownExpanded by remember { mutableStateOf(false) }
     var ratioInput by remember { mutableStateOf(if (vinculado.ratio > 0) vinculado.ratio.toString() else "1") }
-    val productosDisponibles = productosCompra.filter { p -> p.id == vinculado.productoId || !productosVinculados.contains(p.id) }
+    val productoSeleccionado = productosCompra.find { it.id == vinculado.productoId }
+    val productosDisponibles = productosCompra.filter { producto ->
+        producto.id == vinculado.productoId || !productosVinculados.contains(producto.id)
+    }
+
     Card(modifier = Modifier.fillMaxWidth()) {
         Column(modifier = Modifier.padding(8.dp)) {
-            ExposedDropdownMenuBox(expanded = dropdownExpanded, onExpandedChange = { dropdownExpanded = it }) {
-                OutlinedTextField(value = productosCompra.find { it.id == vinculado.productoId }?.nombre ?: "Seleccionar", onValueChange = {}, readOnly = true, label = { Text("Producto") }, trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(dropdownExpanded) }, modifier = Modifier.fillMaxWidth().menuAnchor())
-                ExposedDropdownMenu(expanded = dropdownExpanded, onDismissRequest = { dropdownExpanded = false }) {
-                    productosDisponibles.forEach { p -> DropdownMenuItem(text = { Text("${p.emoji} ${p.nombre}") }, onClick = { onProductoCambiado(p.id); dropdownExpanded = false }) }
+            ExposedDropdownMenuBox(
+                expanded = dropdownExpanded,
+                onExpandedChange = { dropdownExpanded = it }
+            ) {
+                OutlinedTextField(
+                    value = productoSeleccionado?.nombre ?: "Seleccionar",
+                    onValueChange = {},
+                    readOnly = true,
+                    label = { Text("Producto") },
+                    leadingIcon = {
+                        ProductoImagenAvatar(
+                            rawEmoji = productoSeleccionado?.emoji.orEmpty(),
+                            size = 32.dp,
+                            cornerRadius = 8.dp
+                        )
+                    },
+                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(dropdownExpanded) },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .menuAnchor()
+                )
+                ExposedDropdownMenu(
+                    expanded = dropdownExpanded,
+                    onDismissRequest = { dropdownExpanded = false }
+                ) {
+                    productosDisponibles.forEach { producto ->
+                        DropdownMenuItem(
+                            text = { Text(producto.nombre) },
+                            leadingIcon = {
+                                ProductoImagenAvatar(
+                                    rawEmoji = producto.emoji,
+                                    size = 32.dp,
+                                    cornerRadius = 8.dp
+                                )
+                            },
+                            onClick = {
+                                onProductoCambiado(producto.id)
+                                dropdownExpanded = false
+                            }
+                        )
+                    }
                 }
             }
             Spacer(Modifier.height(4.dp))
-            Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.SpaceBetween) {
-                OutlinedTextField(value = ratioInput, onValueChange = { ratioInput = it.replace(',', '.'); it.replace(',', '.').toDoubleOrNull()?.let { r -> onRatioCambiado(r) } }, label = { Text("Cantidad a descontar") }, keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal), singleLine = true, modifier = Modifier.weight(1f))
-                IconButton(onClick = onEliminar) { Icon(Icons.Default.Delete, null, tint = MaterialTheme.colorScheme.error) }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                OutlinedTextField(
+                    value = ratioInput,
+                    onValueChange = {
+                        val normalized = it.replace(',', '.')
+                        ratioInput = normalized
+                        normalized.toDoubleOrNull()?.let { ratio -> onRatioCambiado(ratio) }
+                    },
+                    label = { Text("Cantidad a descontar") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                    singleLine = true,
+                    modifier = Modifier.weight(1f)
+                )
+                IconButton(onClick = onEliminar) {
+                    Icon(Icons.Default.Delete, null, tint = MaterialTheme.colorScheme.error)
+                }
             }
         }
     }


### PR DESCRIPTION
### Motivation
- The Adjust Stock dialog's linked-product selector still expected a literal emoji, but the DB field now stores a JSON-backed avatar model (`emoji` may be an emoji, local photo path or URL), so the selector rendered wrong visuals and lost parity with other product selects.

### Description
- Updated `VinculadoItemRow` in `accounting/android/app/src/main/java/cu/lazaroysr96/sysgdcont/ui/main/screens/InventarioScreen.kt` to use `ProductoImagenAvatar` for the selected product and for each dropdown option so both legacy emoji and JSON-backed images/URLs are displayed correctly.
- Keep the existing duplicate-filtering and selection logic by using a `productoSeleccionado` lookup and `productosDisponibles` filter, preserving behavior when choosing linked components.
- Improved the ratio input handling with decimal normalization and slightly refactored the row layout for readability while preserving the original validation and submit behavior.

### Testing
- Ran `git diff --check` and static checks locally which produced no line-check errors (succeeded).
- Attempted to run a local Kotlin compile via Gradle (`:app:compileDebugKotlin`) but the build was blocked by the environment (missing expected `JAVA_HOME` path and an unresolved KSP plugin in this environment), so automated build verification could not complete (blocked).
- No other automated tests were executed in this environment due to the build/tooling blockers described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19d742030483228716d44bbab072c7)