### PR TITLE
[cont-pro] Mejorar gestión de productos: editar precios e inventario desde Catálogos

### DIFF
--- a/accounting/android/app/src/main/java/cu/lazaroysr96/sysgdcont/data/repository/InventarioRepository.kt
+++ b/accounting/android/app/src/main/java/cu/lazaroysr96/sysgdcont/data/repository/InventarioRepository.kt
@@ -566,6 +566,73 @@ class InventarioRepository @Inject constructor(
         markLocalModified()
     }
 
+
+    suspend fun actualizarPrecioCatalogoProducto(
+        productoId: String,
+        tipoPrecio: String,
+        precio: Double,
+        almacenId: String? = null
+    ) {
+        require(precio >= 0.0) { "El precio no puede ser negativo" }
+        val almacen = almacenId?.let { requireAlmacenActivo(it) } ?: ensureDefaultAlmacen()
+        productoDao.getById(productoId)
+            ?: throw IllegalStateException("No existe el producto seleccionado")
+        appDatabase.withTransaction {
+            when (tipoPrecio) {
+                TipoPrecio.VENTA -> upsertCatalogoVenta(productoId, precio, almacen.id)
+                TipoPrecio.COMPRA -> upsertCatalogoCompra(productoId, precio, almacen.id)
+                else -> throw IllegalArgumentException("Tipo de precio no soportado")
+            }
+            registrarHistoricoPrecio(productoId, tipoPrecio, precio, almacen.id)
+        }
+        markLocalModified()
+    }
+
+    suspend fun ajustarInventarioProductoCatalogo(
+        productoId: String,
+        almacenId: String,
+        cantidad: Double,
+        modo: ModoStock
+    ) {
+        require(cantidad >= 0.0) { "La cantidad no puede ser negativa" }
+        requireAlmacenActivo(almacenId)
+        productoDao.getById(productoId)
+            ?: throw IllegalStateException("No existe el producto seleccionado")
+        val fecha = LocalDate.now().toString()
+        appDatabase.withTransaction {
+            val existente = itemInventarioDao.getByProductoId(productoId, almacenId)
+            val item = existente ?: ItemInventario(
+                id = "stock_${almacenId}_$productoId",
+                productoId = productoId,
+                almacenId = almacenId,
+                tipoProducto = TipoProductoInv.VENTA.name,
+                stockDisponible = 0.0,
+                modoStock = modo.name,
+                ultimaActualizacion = fecha,
+                visibleEnVentas = true
+            ).also { itemInventarioDao.insert(it) }
+            if (item.archivado) {
+                itemInventarioDao.restoreById(item.id, fecha)
+            }
+            itemInventarioDao.actualizarStockYModo(item.id, cantidad, modo.name, fecha)
+            if (modo != ModoStock.VINCULADO) {
+                inventarioVinculoDao.deleteByItemInventarioId(item.id)
+            }
+            registrarMovimiento(
+                tipoMovimiento = TipoMovimientoInventario.AJUSTE,
+                productoId = productoId,
+                cantidad = kotlin.math.abs(cantidad - item.stockDisponible),
+                fecha = fecha,
+                almacenDestinoId = almacenId,
+                stockDestinoAntes = item.stockDisponible,
+                stockDestinoDespues = cantidad,
+                referenciaId = item.id,
+                nota = "Ajuste desde Cuentas y Productos"
+            )
+        }
+        markLocalModified()
+    }
+
     suspend fun getHistorialPreciosProducto(productoId: String): List<PrecioProductoDetalle> =
         precioProductoDao.getHistorialByProducto(productoId)
 

--- a/accounting/android/app/src/main/java/cu/lazaroysr96/sysgdcont/data/repository/LedgerRepository.kt
+++ b/accounting/android/app/src/main/java/cu/lazaroysr96/sysgdcont/data/repository/LedgerRepository.kt
@@ -1671,7 +1671,13 @@ constructor(
 
     suspend fun updateGenerales(data: GeneralesData) {
         val current = getRegistro()
-        saveUserEditedRegistro(current.copy(generales = data))
+        saveUserEditedRegistro(current.copy(generales = data.copy(anio = current.generales.anio)))
+    }
+
+    suspend fun selectFiscalYear(year: Int) {
+        val normalizedYear = year.coerceIn(1900, 2200)
+        val current = getRegistro()
+        saveUserEditedRegistro(current.copy(generales = current.generales.copy(anio = normalizedYear)))
     }
 
     suspend fun addIngreso(
@@ -1701,13 +1707,15 @@ constructor(
             ingresoCuentaId: String = "",
             gasto: Double?,
             gastoCuentaId: String = "",
-            nota: String = ""
+            nota: String = "",
+            year: Int? = null
     ) {
         val ingresoNormalizado = ingreso?.takeIf { it > 0.0 }
         val gastoNormalizado = gasto?.takeIf { it > 0.0 }
         if (ingresoNormalizado == null && gastoNormalizado == null) return
 
         val current = getRegistro()
+        val entryYear = year ?: current.generales.anio
         val ingresos = current.ingresos.toMutableMap()
         val gastos = current.gastos.toMutableMap()
 
@@ -1717,6 +1725,7 @@ constructor(
             monthEntries.add(
                     DayAmountRow(
                             id = entryId,
+                            anio = entryYear,
                             dia = dia.toString(),
                             importe = String.format(Locale.US, "%.2f", it)
                     )
@@ -1731,6 +1740,7 @@ constructor(
             monthEntries.add(
                     DayAmountRow(
                             id = entryId,
+                            anio = entryYear,
                             dia = dia.toString(),
                             importe = String.format(Locale.US, "%.2f", it)
                     )
@@ -1877,16 +1887,21 @@ constructor(
                 }
 
         val monthEntries = entries[month]?.toMutableList() ?: mutableListOf()
-        val previousEntry = monthEntries.firstOrNull { it.dia == oldDia.toString() }
+        val selectedYear = current.generales.anio
+        val previousEntry = monthEntries.firstOrNull { it.anio == selectedYear && it.dia == oldDia.toString() }
 
-        monthEntries.removeAll { it.dia == oldDia.toString() }
+        monthEntries.removeAll { it.anio == selectedYear && it.dia == oldDia.toString() }
 
         if (newDia in 1..31 && importe > 0) {
             val entryId =
                     previousEntry?.id?.takeIf { it.isNotBlank() } ?: UUID.randomUUID().toString()
             monthEntries.add(
-                // TODO: Hay que incluir aqui una funcion para indicar el año del registro
-                    DayAmountRow(entryId, 2026, newDia.toString(), String.format("%.2f", importe))
+                    DayAmountRow(
+                            id = entryId,
+                            anio = selectedYear,
+                            dia = newDia.toString(),
+                            importe = String.format(Locale.US, "%.2f", importe)
+                    )
             )
             saveEntryMetadata(entryId, month, type, cuenta, nota)
         } else {
@@ -1914,8 +1929,9 @@ constructor(
                 }
 
         val monthEntries = entries[month]?.toMutableList() ?: mutableListOf()
-        val idsEliminados = monthEntries.filter { it.dia == dia.toString() }.map { it.id }
-        monthEntries.removeAll { it.dia == dia.toString() }
+        val selectedYear = current.generales.anio
+        val idsEliminados = monthEntries.filter { it.anio == selectedYear && it.dia == dia.toString() }.map { it.id }
+        monthEntries.removeAll { it.anio == selectedYear && it.dia == dia.toString() }
         idsEliminados.forEach { deleteEntryMetadata(it) }
 
         entries[month] = monthEntries
@@ -1971,8 +1987,14 @@ constructor(
 
         val monthEntries = entries[month]?.toMutableList() ?: mutableListOf()
         val entryId = UUID.randomUUID().toString()
-        // TODO: Hay que incluir aqui una funcion para indicar el año del registro
-        monthEntries.add(DayAmountRow(entryId, 2026, dia.toString(), String.format("%.2f", importe)))
+        monthEntries.add(
+                DayAmountRow(
+                        id = entryId,
+                        anio = current.generales.anio,
+                        dia = dia.toString(),
+                        importe = String.format(Locale.US, "%.2f", importe)
+                )
+        )
         saveEntryMetadata(entryId, month, type, cuenta, nota)
 
         entries[month] = monthEntries
@@ -2112,6 +2134,7 @@ constructor(
                     LedgerConstants.MONTHS.first()
                 }
         val dia = fecha.dayOfMonth.toString()
+        val entryYear = fecha.year
         val current = getRegistro()
         val entries =
                 when (type) {
@@ -2124,7 +2147,8 @@ constructor(
         val notas = ingresoGastoNotaDao.getAll().associateBy { it.ingresoGastoId }
         val entry =
                 monthEntries.firstOrNull {
-                    it.dia == dia &&
+                    it.anio == entryYear &&
+                            it.dia == dia &&
                             cuentas[it.id]?.cuentaId == cuentaId &&
                             notas[it.id]?.nota == nota
                 }
@@ -2145,6 +2169,7 @@ constructor(
             monthEntries.add(
                     DayAmountRow(
                             id = entryId,
+                            anio = entryYear,
                             dia = dia,
                             importe = String.format(Locale.US, "%.2f", importeDelta)
                     )
@@ -2783,8 +2808,9 @@ constructor(
     fun calculateAnnualReport(registro: RegistroTCP): AnnualReport {
         val monthly =
                 LedgerConstants.MONTHS.map { month ->
-                    val ingresos = monthTotal(registro.ingresos[month] ?: emptyList())
-                    val gastos = monthTotal(registro.gastos[month] ?: emptyList())
+                    val selectedYear = registro.generales.anio
+                    val ingresos = monthTotal((registro.ingresos[month] ?: emptyList()).filter { it.anio == selectedYear })
+                    val gastos = monthTotal((registro.gastos[month] ?: emptyList()).filter { it.anio == selectedYear })
                     val tribIndex = LedgerConstants.MONTHS.indexOf(month)
                     val tributos =
                             if (tribIndex < registro.tributos.size) {
@@ -3170,8 +3196,9 @@ constructor(
                     if (importe == null || importe <= 0.0) return@mapNotNull null
                     DayAmountRow(
                             id = row.id.ifBlank { UUID.randomUUID().toString() },
+                            anio = row.anio,
                             dia = dia.toString(),
-                            importe = String.format("%.2f", importe)
+                            importe = String.format(Locale.US, "%.2f", importe)
                     )
                     // DayAmountRow(dia = dia.toString(), importe = String.format(Locale.US, "%.2f",importe))
                 }

--- a/accounting/android/app/src/main/java/cu/lazaroysr96/sysgdcont/ui/main/MainScreen.kt
+++ b/accounting/android/app/src/main/java/cu/lazaroysr96/sysgdcont/ui/main/MainScreen.kt
@@ -59,6 +59,8 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Divider
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -172,6 +174,44 @@ private fun openExternalUrl(context: android.content.Context, url: String): Bool
 }
 
 @Composable
+private fun FiscalYearSelector(
+        selectedYear: Int,
+        onYearSelected: (Int) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val currentYear = remember { java.time.Year.now().value }
+    val yearOptions = remember(selectedYear, currentYear) {
+        ((currentYear - 2)..(currentYear + 2)).toMutableSet()
+                .apply { add(selectedYear) }
+                .sortedDescending()
+    }
+
+    Box {
+        TextButton(onClick = { expanded = true }) {
+            Icon(Icons.Default.CalendarToday, contentDescription = null, modifier = Modifier.size(18.dp))
+            Spacer(modifier = Modifier.width(4.dp))
+            Text(selectedYear.toString())
+        }
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            yearOptions.forEach { year ->
+                DropdownMenuItem(
+                        text = { Text(year.toString()) },
+                        onClick = {
+                            expanded = false
+                            if (year != selectedYear) onYearSelected(year)
+                        },
+                        leadingIcon = {
+                            if (year == selectedYear) {
+                                Icon(Icons.Default.Check, contentDescription = null)
+                            }
+                        }
+                )
+            }
+        }
+    }
+}
+
+@Composable
 private fun FeatureUnavailableScreen(message: String) {
     Box(
         modifier = Modifier
@@ -218,6 +258,7 @@ fun MainScreen(
     val currentRoute = navController.currentBackStackEntryAsState().value?.destination?.route
     val authState by authViewModel.uiState.collectAsStateWithLifecycle()
     val ledgerState by ledgerViewModel.uiState.collectAsStateWithLifecycle()
+    val inventarioState by inventarioViewModel.uiState.collectAsStateWithLifecycle()
     val planPurchaseState by planPurchaseViewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
     val drawerState =
@@ -245,6 +286,7 @@ fun MainScreen(
         )
     }
     val syncRoutes = remember { accountingRoutes + DASHBOARD_ROUTE }
+    val fiscalYearRoutes = remember { accountingRoutes + VENTAS_ROUTE }
     var showCreditsInfoDialog by remember { mutableStateOf(false) }
     var showVentasHelpDialog by remember { mutableStateOf(false) }
     var showAccessKeyPasswordDialog by remember { mutableStateOf(false) }
@@ -690,6 +732,20 @@ fun MainScreen(
                                 }
                             },
                             actions = {
+                                if (currentRoute in fiscalYearRoutes) {
+                                    FiscalYearSelector(
+                                            selectedYear = ledgerState.registro.generales.anio,
+                                            onYearSelected = { year ->
+                                                ledgerViewModel.selectFiscalYear(year)
+                                                if (currentRoute == VENTAS_ROUTE) {
+                                                    val adjustedDate = runCatching {
+                                                        inventarioState.fechaTrabajo.withYear(year)
+                                                    }.getOrDefault(inventarioState.fechaTrabajo)
+                                                    inventarioViewModel.setFechaTrabajo(adjustedDate)
+                                                }
+                                            }
+                                    )
+                                }
                                 if (currentRoute == VENTAS_ROUTE) {
                                     IconButton(onClick = { showVentasHelpDialog = true }) {
                                         Icon(
@@ -812,7 +868,8 @@ fun MainScreen(
                                 ingresoCuentaId = ingresoCuentaId.orEmpty(),
                                 gasto = gasto,
                                 gastoCuentaId = gastoCuentaId.orEmpty(),
-                                nota = nota
+                                nota = nota,
+                                year = fecha.year
                             )
                         },
                                 userName = authState.currentUser?.name ?: "Usuario",

--- a/accounting/android/app/src/main/java/cu/lazaroysr96/sysgdcont/ui/main/screens/CatalogosScreen.kt
+++ b/accounting/android/app/src/main/java/cu/lazaroysr96/sysgdcont/ui/main/screens/CatalogosScreen.kt
@@ -27,7 +27,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import cu.lazaroysr96.sysgdcont.data.model.Almacen
 import cu.lazaroysr96.sysgdcont.data.model.CuentaContable
+import cu.lazaroysr96.sysgdcont.data.model.ItemInventario
+import cu.lazaroysr96.sysgdcont.data.model.ModoStock
 import cu.lazaroysr96.sysgdcont.data.model.NaturalezaCuenta
 import cu.lazaroysr96.sysgdcont.data.model.PrecioProductoDetalle
 import cu.lazaroysr96.sysgdcont.data.model.TipoPrecio
@@ -81,8 +84,17 @@ fun CatalogosScreen(
     var selectedTab    by remember { mutableStateOf(0) }
     val productosState by inventarioViewModel.uiState.collectAsStateWithLifecycle()
     val ledgerState    by ledgerViewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
 
-    Column(modifier = Modifier.fillMaxSize()) {
+    LaunchedEffect(productosState.snackbarMessage) {
+        productosState.snackbarMessage?.let { message ->
+            snackbarHostState.showSnackbar(message)
+            inventarioViewModel.clearSnackbar()
+        }
+    }
+
+    Scaffold(snackbarHost = { SnackbarHost(snackbarHostState) }) { padding ->
+    Column(modifier = Modifier.fillMaxSize().padding(padding)) {
         TabRow(selectedTabIndex = selectedTab) {
             listOf("Cuentas", "Productos").forEachIndexed { index, title ->
                 Tab(
@@ -107,12 +119,17 @@ fun CatalogosScreen(
             )
             1 -> ProductosTab(
                 productos        = productosState.productosBase,
+                almacenes        = productosState.almacenes,
+                itemsInventario  = (productosState.itemsInventarioVenta + productosState.itemsInventarioCompra).distinctBy { it.id },
                 onAddProduct     = inventarioViewModel::agregarProductoBase,
                 onEditProduct    = inventarioViewModel::actualizarProductoBase,
                 onDeleteProduct  = inventarioViewModel::deleteProductoBase,
+                onUpdatePrice    = inventarioViewModel::actualizarPrecioProductoCatalogo,
+                onUpdateStock    = inventarioViewModel::ajustarInventarioProductoCatalogo,
                 loadPriceHistory = inventarioViewModel::obtenerHistorialPreciosProducto
             )
         }
+    }
     }
 }
 
@@ -123,9 +140,13 @@ fun CatalogosScreen(
 @Composable
 private fun ProductosTab(
     productos: List<Producto>,
+    almacenes: List<Almacen>,
+    itemsInventario: List<ItemInventario>,
     onAddProduct:  (nombre: String, imagenJson: String, unidad: String, descripcion: String) -> Unit,
     onEditProduct: (id: String, nombre: String, imagenJson: String, unidad: String, descripcion: String) -> Unit,
     onDeleteProduct: (id: String) -> Unit,
+    onUpdatePrice: (productoId: String, tipoPrecio: String, precio: Double, almacenId: String) -> Unit,
+    onUpdateStock: (productoId: String, almacenId: String, cantidad: Double, modo: ModoStock) -> Unit,
     loadPriceHistory: suspend (String) -> List<PrecioProductoDetalle>
 ) {
     var productoDetalle  by remember { mutableStateOf<Producto?>(null) }
@@ -209,7 +230,11 @@ private fun ProductosTab(
     productoDetalle?.let { producto ->
         ProductoDetalleDialog(
             producto = producto,
+            almacenes = almacenes,
+            itemsInventario = itemsInventario.filter { it.productoId == producto.id },
             loadPriceHistory = loadPriceHistory,
+            onUpdatePrice = onUpdatePrice,
+            onUpdateStock = onUpdateStock,
             onDismiss = { productoDetalle = null },
             onEdit = {
                 productoDetalle = null
@@ -239,7 +264,11 @@ private fun ProductosTab(
 @Composable
 private fun ProductoDetalleDialog(
     producto: Producto,
+    almacenes: List<Almacen>,
+    itemsInventario: List<ItemInventario>,
     loadPriceHistory: suspend (String) -> List<PrecioProductoDetalle>,
+    onUpdatePrice: (productoId: String, tipoPrecio: String, precio: Double, almacenId: String) -> Unit,
+    onUpdateStock: (productoId: String, almacenId: String, cantidad: Double, modo: ModoStock) -> Unit,
     onDismiss: () -> Unit,
     onEdit: () -> Unit,
     onDelete: () -> Unit,
@@ -254,6 +283,8 @@ private fun ProductoDetalleDialog(
     val preciosCompra = remember(historial) { historial.filter { it.tipoPrecio == TipoPrecio.COMPRA && it.activo } }
     val imagen = remember(producto.emoji) { producto.emoji.toProductoImagen() }
     val colorScheme = MaterialTheme.colorScheme
+    var priceEditor by remember { mutableStateOf<String?>(null) }
+    var stockEditorOpen by remember { mutableStateOf(false) }
 
     Dialog(
         onDismissRequest = onDismiss,
@@ -372,16 +403,24 @@ private fun ProductoDetalleDialog(
                             precios = preciosVenta,
                             containerColor = colorScheme.primaryContainer,
                             contentColor = colorScheme.onPrimaryContainer,
-                            modifier = Modifier.weight(1f).fillMaxHeight()
+                            modifier = Modifier.weight(1f).fillMaxHeight(),
+                            onEdit = { priceEditor = TipoPrecio.VENTA }
                         )
                         PrecioVigenteCard(
                             titulo = "Compra",
                             precios = preciosCompra,
                             containerColor = colorScheme.secondaryContainer,
                             contentColor = colorScheme.onSecondaryContainer,
-                            modifier = Modifier.weight(1f).fillMaxHeight()
+                            modifier = Modifier.weight(1f).fillMaxHeight(),
+                            onEdit = { priceEditor = TipoPrecio.COMPRA }
                         )
                     }
+
+                    InventoryAvailabilitySection(
+                        items = itemsInventario,
+                        almacenes = almacenes,
+                        onEdit = { stockEditorOpen = true }
+                    )
 
                     // Historial
                     if (historial.isNotEmpty()) {
@@ -436,6 +475,33 @@ private fun ProductoDetalleDialog(
             }
         }
     }
+
+    priceEditor?.let { tipoPrecio ->
+        EditPriceDialog(
+            producto = producto,
+            tipoPrecio = tipoPrecio,
+            almacenes = almacenes,
+            currentPrice = (if (tipoPrecio == TipoPrecio.VENTA) preciosVenta else preciosCompra).firstOrNull(),
+            onDismiss = { priceEditor = null },
+            onConfirm = { almacenId, precio ->
+                onUpdatePrice(producto.id, tipoPrecio, precio, almacenId)
+                priceEditor = null
+            }
+        )
+    }
+
+    if (stockEditorOpen) {
+        EditStockDialog(
+            producto = producto,
+            almacenes = almacenes,
+            items = itemsInventario,
+            onDismiss = { stockEditorOpen = false },
+            onConfirm = { almacenId, cantidad, modo ->
+                onUpdateStock(producto.id, almacenId, cantidad, modo)
+                stockEditorOpen = false
+            }
+        )
+    }
 }
 
 // ── Auxiliares ────────────────────────────────────────────────────────────────
@@ -447,6 +513,7 @@ private fun PrecioVigenteCard(
     containerColor: Color,
     contentColor: Color,
     modifier: Modifier = Modifier,
+    onEdit: () -> Unit = {}
 ) {
     Surface(
         modifier = modifier,
@@ -457,11 +524,20 @@ private fun PrecioVigenteCard(
             modifier = Modifier.padding(14.dp),
             verticalArrangement = Arrangement.spacedBy(6.dp)
         ) {
-            Text(
-                text = titulo,
-                style = MaterialTheme.typography.labelMedium,
-                color = contentColor.copy(alpha = 0.75f)
-            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = titulo,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = contentColor.copy(alpha = 0.75f)
+                )
+                IconButton(onClick = onEdit, modifier = Modifier.size(32.dp)) {
+                    Icon(Icons.Default.Edit, contentDescription = "Editar precio", tint = contentColor)
+                }
+            }
             if (precios.isEmpty()) {
                 Text(
                     text = "Sin precio",
@@ -569,6 +645,165 @@ private fun HistorialPrecioItem(item: PrecioProductoDetalle) {
 
 
 
+
+@Composable
+private fun InventoryAvailabilitySection(
+    items: List<ItemInventario>,
+    almacenes: List<Almacen>,
+    onEdit: () -> Unit
+) {
+    Surface(
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.45f),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(modifier = Modifier.padding(14.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text("Inventario disponible", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                TextButton(onClick = onEdit) {
+                    Icon(Icons.Default.Edit, contentDescription = null, modifier = Modifier.size(16.dp))
+                    Spacer(Modifier.width(6.dp))
+                    Text("Modificar")
+                }
+            }
+            if (items.isEmpty()) {
+                Text("Sin inventario registrado", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            } else {
+                items.forEach { item ->
+                    val almacen = almacenes.firstOrNull { it.id == item.almacenId }?.nombre ?: item.almacenId
+                    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                        Text(almacen, modifier = Modifier.weight(1f), style = MaterialTheme.typography.bodyMedium)
+                        Text(
+                            text = if (item.modoStock == ModoStock.ILIMITADO.name) "Ilimitado" else "${"%.2f".format(item.stockDisponible)}",
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EditPriceDialog(
+    producto: Producto,
+    tipoPrecio: String,
+    almacenes: List<Almacen>,
+    currentPrice: PrecioProductoDetalle?,
+    onDismiss: () -> Unit,
+    onConfirm: (String, Double) -> Unit
+) {
+    val defaultAlmacen = currentPrice?.almacenId ?: almacenes.firstOrNull()?.id.orEmpty()
+    var almacenId by remember(defaultAlmacen) { mutableStateOf(defaultAlmacen) }
+    var precioText by remember(currentPrice) { mutableStateOf(currentPrice?.precio?.toString().orEmpty()) }
+    val precio = precioText.replace(',', '.').toDoubleOrNull()
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Editar precio de ${TipoPrecio.label(tipoPrecio).lowercase()}") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                Text(producto.nombre, style = MaterialTheme.typography.titleSmall)
+                AlmacenSelector(almacenes = almacenes, selectedId = almacenId, onSelected = { almacenId = it })
+                OutlinedTextField(
+                    value = precioText,
+                    onValueChange = { precioText = it },
+                    label = { Text("Precio") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                enabled = almacenId.isNotBlank() && precio != null && precio >= 0.0,
+                onClick = { onConfirm(almacenId, precio ?: 0.0) }
+            ) { Text("Guardar") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancelar") } }
+    )
+}
+
+@Composable
+private fun EditStockDialog(
+    producto: Producto,
+    almacenes: List<Almacen>,
+    items: List<ItemInventario>,
+    onDismiss: () -> Unit,
+    onConfirm: (String, Double, ModoStock) -> Unit
+) {
+    val defaultItem = items.firstOrNull()
+    val defaultAlmacen = defaultItem?.almacenId ?: almacenes.firstOrNull()?.id.orEmpty()
+    var almacenId by remember(defaultAlmacen) { mutableStateOf(defaultAlmacen) }
+    val selectedItem = items.firstOrNull { it.almacenId == almacenId }
+    var cantidadText by remember(selectedItem) { mutableStateOf((selectedItem?.stockDisponible ?: 0.0).toString()) }
+    var modo by remember(selectedItem) { mutableStateOf(runCatching { ModoStock.valueOf(selectedItem?.modoStock ?: ModoStock.MANUAL.name) }.getOrDefault(ModoStock.MANUAL)) }
+    val cantidad = cantidadText.replace(',', '.').toDoubleOrNull()
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Modificar inventario") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                Text(producto.nombre, style = MaterialTheme.typography.titleSmall)
+                AlmacenSelector(almacenes = almacenes, selectedId = almacenId, onSelected = { almacenId = it })
+                OutlinedTextField(
+                    value = cantidadText,
+                    onValueChange = { cantidadText = it },
+                    label = { Text("Cantidad disponible") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    listOf(ModoStock.MANUAL, ModoStock.ILIMITADO).forEach { option ->
+                        FilterChip(
+                            selected = modo == option,
+                            onClick = { modo = option },
+                            label = { Text(option.name.lowercase().replaceFirstChar { it.uppercase() }) }
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                enabled = almacenId.isNotBlank() && cantidad != null && cantidad >= 0.0,
+                onClick = { onConfirm(almacenId, cantidad ?: 0.0, modo) }
+            ) { Text("Guardar") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancelar") } }
+    )
+}
+
+@Composable
+private fun AlmacenSelector(
+    almacenes: List<Almacen>,
+    selectedId: String,
+    onSelected: (String) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val selectedName = almacenes.firstOrNull { it.id == selectedId }?.nombre ?: "Seleccionar almacén"
+    Box {
+        OutlinedButton(onClick = { expanded = true }, modifier = Modifier.fillMaxWidth()) {
+            Text(selectedName, modifier = Modifier.weight(1f))
+            Icon(Icons.Default.ArrowDropDown, contentDescription = null)
+        }
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            almacenes.forEach { almacen ->
+                DropdownMenuItem(
+                    text = { Text(if (almacen.principal) "${almacen.nombre} (principal)" else almacen.nombre) },
+                    onClick = {
+                        onSelected(almacen.id)
+                        expanded = false
+                    }
+                )
+            }
+        }
+    }
+}
 
 
 @Composable

--- a/accounting/android/app/src/main/java/cu/lazaroysr96/sysgdcont/ui/main/screens/GastosScreen.kt
+++ b/accounting/android/app/src/main/java/cu/lazaroysr96/sysgdcont/ui/main/screens/GastosScreen.kt
@@ -31,6 +31,7 @@ import java.util.Calendar
 fun GastosScreen(viewModel: LedgerViewModel) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val cuentasPorId = remember(uiState.cuentasContables) { uiState.cuentasContables.associateBy { it.id } }
+    val selectedYear = uiState.registro.generales.anio
     var showDialog by remember { mutableStateOf(false) }
     var isEditMode by remember { mutableStateOf(false) }
     var editEntry by remember { mutableStateOf<Pair<String, DayAmountRow>?>(null) }
@@ -54,7 +55,7 @@ fun GastosScreen(viewModel: LedgerViewModel) {
                 .padding(padding)
                 .padding(16.dp)
         ) {
-            Text("Gastos", style = MaterialTheme.typography.titleLarge)
+            Text("Gastos ${selectedYear}", style = MaterialTheme.typography.titleLarge)
             Spacer(modifier = Modifier.height(8.dp))
 
             val totalGastos = uiState.annualReport?.totalGastos ?: 0.0
@@ -64,7 +65,8 @@ fun GastosScreen(viewModel: LedgerViewModel) {
 
             LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 items(LedgerConstants.MONTHS) { month ->
-                    val entries = uiState.registro.gastos[month] ?: emptyList()
+                    val entries = (uiState.registro.gastos[month] ?: emptyList())
+                        .filter { it.anio == selectedYear }
                     val total = entries.sumOf { it.importe.toDoubleOrNull() ?: 0.0 }
                     val isExpanded = expandedMonths.contains(month)
 

--- a/accounting/android/app/src/main/java/cu/lazaroysr96/sysgdcont/ui/main/screens/GeneralesScreen.kt
+++ b/accounting/android/app/src/main/java/cu/lazaroysr96/sysgdcont/ui/main/screens/GeneralesScreen.kt
@@ -3,6 +3,8 @@ package cu.lazaroysr96.sysgdcont.ui.main.screens
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CalendarToday
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -22,7 +24,7 @@ fun GeneralesScreen(viewModel: LedgerViewModel) {
 
     var nombre by remember(generales) { mutableStateOf(generales.nombre) }
     var nit by remember(generales) { mutableStateOf(generales.nit) }
-    var anio by remember(generales) { mutableStateOf(generales.anio.toString()) }
+    val selectedYear = generales.anio
     var actividad by remember(generales) { mutableStateOf(generales.actividad) }
     var codigo by remember(generales) { mutableStateOf(generales.codigo) }
     var fiscalCalle by remember(generales) { mutableStateOf(generales.fiscalCalle) }
@@ -62,12 +64,14 @@ fun GeneralesScreen(viewModel: LedgerViewModel) {
             )
             Spacer(modifier = Modifier.width(8.dp))
             OutlinedTextField(
-                value = anio,
-                onValueChange = { anio = it.filter { c -> c.isDigit() }.take(4) },
+                value = selectedYear.toString(),
+                onValueChange = {},
+                readOnly = true,
                 label = { Text("Año") },
+                leadingIcon = { Icon(Icons.Default.CalendarToday, contentDescription = null) },
+                supportingText = { Text("Se controla con el selector global de año.") },
                 modifier = Modifier.weight(1f),
-                singleLine = true,
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+                singleLine = true
             )
         }
 
@@ -172,7 +176,7 @@ fun GeneralesScreen(viewModel: LedgerViewModel) {
                     GeneralesData(
                         nombre = nombre,
                         nit = nit,
-                        anio = anio.toIntOrNull() ?: 2026,
+                        anio = selectedYear,
                         actividad = actividad,
                         codigo = codigo,
                         fiscalCalle = fiscalCalle,

--- a/accounting/android/app/src/main/java/cu/lazaroysr96/sysgdcont/ui/main/screens/IngresosScreen.kt
+++ b/accounting/android/app/src/main/java/cu/lazaroysr96/sysgdcont/ui/main/screens/IngresosScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.platform.LocalContext
 fun IngresosScreen(viewModel: LedgerViewModel) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val cuentasPorId = remember(uiState.cuentasContables) { uiState.cuentasContables.associateBy { it.id } }
+    val selectedYear = uiState.registro.generales.anio
     var showDialog by remember { mutableStateOf(false) }
     var isEditMode by remember { mutableStateOf(false) }
     var editEntry by remember { mutableStateOf<Pair<String, DayAmountRow>?>(null) }
@@ -57,7 +58,7 @@ fun IngresosScreen(viewModel: LedgerViewModel) {
                 .padding(padding)
                 .padding(16.dp)
         ) {
-            Text("Ingresos", style = MaterialTheme.typography.titleLarge)
+            Text("Ingresos ${selectedYear}", style = MaterialTheme.typography.titleLarge)
             Spacer(modifier = Modifier.height(8.dp))
 
             val totalIngresos = uiState.annualReport?.totalIngresos ?: 0.0
@@ -67,7 +68,8 @@ fun IngresosScreen(viewModel: LedgerViewModel) {
 
             LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 items(LedgerConstants.MONTHS) { month ->
-                    val entries = uiState.registro.ingresos[month] ?: emptyList()
+                    val entries = (uiState.registro.ingresos[month] ?: emptyList())
+                        .filter { it.anio == selectedYear }
                     val total = entries.sumOf { it.importe.toDoubleOrNull() ?: 0.0 }
                     val isExpanded = expandedMonths.contains(month)
 

--- a/accounting/android/app/src/main/java/cu/lazaroysr96/sysgdcont/viewmodel/InventarioViewModel.kt
+++ b/accounting/android/app/src/main/java/cu/lazaroysr96/sysgdcont/viewmodel/InventarioViewModel.kt
@@ -16,6 +16,7 @@ import cu.lazaroysr96.sysgdcont.data.model.FormaPago
 import cu.lazaroysr96.sysgdcont.data.model.RolTercero
 import cu.lazaroysr96.sysgdcont.data.model.TerceroListItem
 import cu.lazaroysr96.sysgdcont.data.model.TipoCuentaTercero
+import cu.lazaroysr96.sysgdcont.data.model.TipoPrecio
 import cu.lazaroysr96.sysgdcont.data.model.TipoProductoInv
 import cu.lazaroysr96.sysgdcont.data.model.ModoStock
 import cu.lazaroysr96.sysgdcont.data.model.MovimientoInventario
@@ -708,6 +709,32 @@ class InventarioViewModel @Inject constructor(
 
     suspend fun obtenerHistorialPreciosProducto(productoId: String): List<PrecioProductoDetalle> =
         repo.getHistorialPreciosProducto(productoId)
+
+
+
+    fun actualizarPrecioProductoCatalogo(productoId: String, tipoPrecio: String, precio: Double, almacenId: String) {
+        viewModelScope.launch {
+            try {
+                repo.actualizarPrecioCatalogoProducto(productoId, tipoPrecio, precio, almacenId)
+                val etiqueta = if (tipoPrecio == TipoPrecio.VENTA) "venta" else "compra"
+                _uiState.update { it.copy(snackbarMessage = "Precio de $etiqueta actualizado en Cuentas y Productos") }
+            } catch (e: Exception) {
+                _uiState.update { it.copy(snackbarMessage = e.message ?: "Error al actualizar precio") }
+            }
+        }
+    }
+
+    fun ajustarInventarioProductoCatalogo(productoId: String, almacenId: String, cantidad: Double, modo: ModoStock) {
+        viewModelScope.launch {
+            try {
+                repo.ajustarInventarioProductoCatalogo(productoId, almacenId, cantidad, modo)
+                _uiState.update { it.copy(snackbarMessage = "Inventario actualizado en Cuentas y Productos") }
+            } catch (e: Exception) {
+                _uiState.update { it.copy(snackbarMessage = e.message ?: "Error al actualizar inventario") }
+            }
+        }
+    }
+
 
     fun deleteProductoBase(id: String) {
         viewModelScope.launch {

--- a/accounting/android/app/src/main/java/cu/lazaroysr96/sysgdcont/viewmodel/LedgerViewModel.kt
+++ b/accounting/android/app/src/main/java/cu/lazaroysr96/sysgdcont/viewmodel/LedgerViewModel.kt
@@ -151,6 +151,12 @@ class LedgerViewModel @Inject constructor(
         }
     }
 
+    fun selectFiscalYear(year: Int) {
+        viewModelScope.launch {
+            ledgerRepository.selectFiscalYear(year)
+        }
+    }
+
     fun addIngreso(month: String, dia: Int, importe: Double, cuenta: String = "", nota: String = "") {
         viewModelScope.launch {
             ledgerRepository.addIngreso(month, dia, importe, cuenta, nota)
@@ -170,7 +176,8 @@ class LedgerViewModel @Inject constructor(
         ingresoCuentaId: String = "",
         gasto: Double?,
         gastoCuentaId: String = "",
-        nota: String = ""
+        nota: String = "",
+        year: Int? = null
     ) {
         viewModelScope.launch {
             ledgerRepository.registrarOperacionRapida(
@@ -180,7 +187,8 @@ class LedgerViewModel @Inject constructor(
                 ingresoCuentaId = ingresoCuentaId,
                 gasto = gasto,
                 gastoCuentaId = gastoCuentaId,
-                nota = nota
+                nota = nota,
+                year = year
             )
         }
     }

--- a/client/src/accounting/core/types/accountingTypes.ts
+++ b/client/src/accounting/core/types/accountingTypes.ts
@@ -352,11 +352,18 @@ export type TributoRow = {
   cuotaMensual: string;
 };
 
+export type RegistroAnualTCP = {
+  ingresos: MonthEntries;
+  gastos: MonthEntries;
+  tributos: TributoRow[];
+};
+
 export type RegistroTCP = {
   generales: GeneralesData;
   ingresos: MonthEntries;
   gastos: MonthEntries;
   tributos: TributoRow[];
+  registrosPorAnio?: Record<string, RegistroAnualTCP>;
   inventario: InventarioRegistro;
   terceros: TercerosRegistro;
 };

--- a/client/src/gctcp/GC_TCP.tsx
+++ b/client/src/gctcp/GC_TCP.tsx
@@ -5,12 +5,27 @@ import Loading from "@/components/Loading";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { useAuthSession } from "@/hooks/connection/useAuthSession";
 import { useToast } from "@/hooks/use-toast";
 import api from "@/lib/api";
 import { cn } from "@/lib/utils";
 import type { CatalogoCompra, CatalogoVenta, CloudLedgerContainer, HistorialPrecio, Moneda, MonedaTasa, MonedaTasaHistorial, StockRegistro, WalletMovimiento, WalletMovimientoTipo, WalletReferenciaTipo, WalletTipo } from "../accounting/core/types/accountingTypes";
-import { calculateWorkspaceAnalysis, formatLedgerDate, formatMoney } from "./accountingMath";
+import {
+  calculateWorkspaceAnalysis,
+  ensureRegistroYear,
+  formatLedgerDate,
+  formatMoney,
+  getWorkspaceForYear,
+  getWorkspaceYears,
+  normalizeLedgerYear,
+} from "./accountingMath";
 import { EmptyState, GcTcpSidebar } from "./components";
 import { DeleteWorkspaceDialog } from "./DeleteWorkspaceDialog";
 import { NomenclatorsView } from "./nomenclators/NomenclatorsView";
@@ -60,6 +75,8 @@ const GC_TCP: FC = () => {
     null,
   );
   const [savingProductChanges, setSavingProductChanges] = useState(false);
+  const [selectedYear, setSelectedYear] = useState(new Date().getFullYear());
+  const [savingYear, setSavingYear] = useState(false);
   const [savingWallet, setSavingWallet] = useState(false);
 
   useEffect(() => {
@@ -95,18 +112,31 @@ const GC_TCP: FC = () => {
   }, [loadLedger, user]);
 
   const ledger = data?.registro ?? null;
+  const baseActiveWorkspace =
+    ledger?.workspaces.find((workspace) => workspace.id === activeWorkspaceId) ??
+    ledger?.workspaces[0] ??
+    null;
+  const yearOptions = useMemo(
+    () => getWorkspaceYears(baseActiveWorkspace),
+    [baseActiveWorkspace],
+  );
   const analyses = useMemo(
     () =>
       ledger?.workspaces.map((workspace) =>
-        calculateWorkspaceAnalysis(workspace),
+        calculateWorkspaceAnalysis(getWorkspaceForYear(workspace, selectedYear)),
       ) ?? [],
-    [ledger],
+    [ledger, selectedYear],
   );
   const activeAnalysis =
     analyses.find((analysis) => analysis.workspace.id === activeWorkspaceId) ??
     analyses[0] ??
     null;
   const activeWorkspace = activeAnalysis?.workspace ?? null;
+
+  useEffect(() => {
+    if (!baseActiveWorkspace) return;
+    setSelectedYear(normalizeLedgerYear(baseActiveWorkspace.registro.generales?.anio));
+  }, [activeWorkspaceId, baseActiveWorkspace]);
 
   const totals = useMemo(
     () => ({
@@ -138,6 +168,53 @@ const GC_TCP: FC = () => {
     api,
     toast,
   });
+
+
+  const handleSelectYear = async (yearValue: string) => {
+    const nextYear = normalizeLedgerYear(yearValue);
+    if (!ledger || !baseActiveWorkspace || nextYear === selectedYear) return;
+
+    const previousYear = selectedYear;
+    const updatedLedger: CloudLedgerContainer = {
+      ...ledger,
+      workspaces: ledger.workspaces.map((workspace) =>
+        workspace.id === baseActiveWorkspace.id
+          ? {
+              ...workspace,
+              registro: ensureRegistroYear(workspace.registro, nextYear),
+            }
+          : workspace,
+      ),
+    };
+
+    setSelectedYear(nextYear);
+    setData((current) =>
+      current ? { ...current, registro: updatedLedger } : current,
+    );
+    setSavingYear(true);
+    try {
+      await api.put("/api/cont-ledger", {
+        registro: updatedLedger,
+        inventarioRegistro: data?.inventarioRegistro ?? null,
+      });
+      toast({
+        title: "Año fiscal seleccionado",
+        description: `Ingresos, gastos y operaciones POS se muestran para ${nextYear}.`,
+      });
+    } catch {
+      setSelectedYear(previousYear);
+      setData((current) =>
+        current ? { ...current, registro: ledger } : current,
+      );
+      toast({
+        title: "No se pudo cambiar el año fiscal",
+        description: "Se mantuvo el año anterior para no desincronizar los registros.",
+        variant: "destructive",
+      });
+    } finally {
+      setSavingYear(false);
+    }
+  };
 
   const handleSelectWorkspace = async (workspaceId: string) => {
     if (!ledger || workspaceId === activeWorkspaceId) return;
@@ -803,7 +880,7 @@ console.log(activeWorkspace?.accounting.monedas);
       case "libroDiario":
         return <LibroDiarioView workspace={activeWorkspace} />;
       case "ventas":
-        return <PointOfSaleView workspace={activeWorkspace} />;
+        return <PointOfSaleView workspace={activeWorkspace} selectedYear={selectedYear} />;
       case "cajaBanco":
         return (
           <CajaBanco
@@ -945,7 +1022,26 @@ console.log(activeWorkspace?.accounting.monedas);
                 </p>
               </div>
             </div>
-            <div className="flex items-center gap-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <div className="flex items-center gap-2 rounded-md border border-slate-200 bg-white px-2 py-1 dark:border-slate-800 dark:bg-slate-900">
+                <span className="text-xs font-medium uppercase text-slate-500 dark:text-slate-400">Año</span>
+                <Select
+                  value={String(selectedYear)}
+                  onValueChange={(value) => void handleSelectYear(value)}
+                  disabled={savingYear}
+                >
+                  <SelectTrigger className="h-8 w-[5.75rem] border-0 px-2 shadow-none focus:ring-0">
+                    <SelectValue placeholder="Año" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {yearOptions.map((year) => (
+                      <SelectItem key={year} value={String(year)}>
+                        {year}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
               <Badge variant="outline">
                 {ledger.workspaces.length} workspace
                 {ledger.workspaces.length === 1 ? "" : "s"}

--- a/client/src/gctcp/GC_TCP.tsx
+++ b/client/src/gctcp/GC_TCP.tsx
@@ -9,12 +9,13 @@ import { useAuthSession } from "@/hooks/connection/useAuthSession";
 import { useToast } from "@/hooks/use-toast";
 import api from "@/lib/api";
 import { cn } from "@/lib/utils";
-import type { CloudLedgerContainer, Moneda, MonedaTasa, MonedaTasaHistorial, WalletMovimiento, WalletMovimientoTipo, WalletReferenciaTipo, WalletTipo } from "../accounting/core/types/accountingTypes";
+import type { CatalogoCompra, CatalogoVenta, CloudLedgerContainer, HistorialPrecio, Moneda, MonedaTasa, MonedaTasaHistorial, StockRegistro, WalletMovimiento, WalletMovimientoTipo, WalletReferenciaTipo, WalletTipo } from "../accounting/core/types/accountingTypes";
 import { calculateWorkspaceAnalysis, formatLedgerDate } from "./accountingMath";
 import { EmptyState, GcTcpSidebar } from "./components";
 import { DeleteWorkspaceDialog } from "./DeleteWorkspaceDialog";
 import { NomenclatorsView } from "./nomenclators/NomenclatorsView";
 import { PointOfSaleView } from "./pos/PointOfSaleView";
+import type { ProductPriceUpdate, ProductStockUpdate } from "./products/ProductEditDialogs";
 import { getProductUsage } from "./products/productUtils";
 import { getViewTitle } from "./navigation";
 import type { GcTcpView, LedgerApiResponse } from "./types";
@@ -50,6 +51,7 @@ const GC_TCP: FC = () => {
   const [deletingProductId, setDeletingProductId] = useState<string | null>(
     null,
   );
+  const [savingProductChanges, setSavingProductChanges] = useState(false);
   const [savingWallet, setSavingWallet] = useState(false);
 
   useEffect(() => {
@@ -276,6 +278,180 @@ const GC_TCP: FC = () => {
     } finally {
       setDeletingProductId(null);
     }
+  };
+
+
+  const persistProductLedger = async (updatedLedger: CloudLedgerContainer, successTitle: string, failureTitle: string) => {
+    setSavingProductChanges(true);
+    try {
+      await api.put("/api/cont-ledger", {
+        registro: updatedLedger,
+        inventarioRegistro: data?.inventarioRegistro ?? null,
+      });
+      setData((current) =>
+        current ? { ...current, registro: updatedLedger } : current,
+      );
+      toast({ title: successTitle });
+    } catch {
+      toast({ title: failureTitle, variant: "destructive" });
+    } finally {
+      setSavingProductChanges(false);
+    }
+  };
+
+  const handleUpdateProductPrice = async (payload: ProductPriceUpdate) => {
+    if (!ledger || !activeWorkspace) return;
+    const now = Date.now();
+    const isoDate = new Date(now).toISOString();
+    const product = activeWorkspace.registro.inventario.productos.find((item) => item.id === payload.productId);
+    if (!product) return;
+
+    const updatedWorkspaces = ledger.workspaces.map((workspace) => {
+      if (workspace.id !== activeWorkspace.id) return workspace;
+      const { inventario } = workspace.registro;
+      const principalWarehouse = inventario.almacenes.find((almacen) => almacen.principal) ?? inventario.almacenes[0] ?? null;
+      const existingSaleItems = inventario.catalogoVentas.filter((item) => item.productoId === payload.productId && item.activo);
+      const existingPurchaseItems = inventario.catalogoCompras.filter((item) => item.productoId === payload.productId && item.activo);
+      const newPriceHistory: HistorialPrecio = {
+        id: `price-${payload.productId}-${payload.tipoPrecio.toLowerCase()}-${now}`,
+        productoId: payload.productId,
+        almacenId: principalWarehouse?.id ?? "principal",
+        fechaDesde: isoDate,
+        precio: payload.precio,
+        moneda: "CUP",
+        tipoPrecio: payload.tipoPrecio,
+        activo: true,
+        createdAt: now,
+      };
+
+      const catalogoVentas = payload.tipoPrecio === "VENTA"
+        ? existingSaleItems.length > 0
+          ? inventario.catalogoVentas.map((item): CatalogoVenta =>
+              item.productoId === payload.productId && item.activo
+                ? { ...item, precioReferencia: payload.precio }
+                : item,
+            )
+          : principalWarehouse
+            ? [
+                ...inventario.catalogoVentas,
+                {
+                  id: `venta-${payload.productId}-${now}`,
+                  productoId: payload.productId,
+                  precioReferencia: payload.precio,
+                  almacenId: principalWarehouse.id,
+                  activo: true,
+                },
+              ]
+            : inventario.catalogoVentas
+        : inventario.catalogoVentas;
+
+      const catalogoCompras = payload.tipoPrecio === "COMPRA"
+        ? existingPurchaseItems.length > 0
+          ? inventario.catalogoCompras.map((item): CatalogoCompra =>
+              item.productoId === payload.productId && item.activo
+                ? { ...item, precioReferencia: payload.precio }
+                : item,
+            )
+          : principalWarehouse
+            ? [
+                ...inventario.catalogoCompras,
+                {
+                  id: `compra-${payload.productId}-${now}`,
+                  productoId: payload.productId,
+                  precioReferencia: payload.precio,
+                  almacenDestinoId: principalWarehouse.id,
+                  activo: true,
+                },
+              ]
+            : inventario.catalogoCompras
+        : inventario.catalogoCompras;
+
+      return {
+        ...workspace,
+        registro: {
+          ...workspace.registro,
+          inventario: {
+            ...inventario,
+            productos: inventario.productos.map((item) =>
+              item.id === payload.productId ? { ...item, precio: payload.precio } : item,
+            ),
+            catalogoVentas,
+            catalogoCompras,
+            historialPrecios: [
+              ...inventario.historialPrecios.map((item) =>
+                item.productoId === payload.productId && item.tipoPrecio === payload.tipoPrecio
+                  ? { ...item, activo: false }
+                  : item,
+              ),
+              newPriceHistory,
+            ],
+          },
+        },
+      };
+    });
+
+    await persistProductLedger(
+      { ...ledger, workspaces: updatedWorkspaces },
+      "Precio de producto actualizado",
+      "No se pudo actualizar el precio",
+    );
+  };
+
+  const handleUpdateProductStock = async (payload: ProductStockUpdate) => {
+    if (!ledger || !activeWorkspace) return;
+    const now = Date.now();
+    const product = activeWorkspace.registro.inventario.productos.find((item) => item.id === payload.productId);
+    if (!product) return;
+
+    const updatedWorkspaces = ledger.workspaces.map((workspace) => {
+      if (workspace.id !== activeWorkspace.id) return workspace;
+      const { inventario } = workspace.registro;
+      const existingStock = inventario.stock.find(
+        (item) => item.productoId === payload.productId && item.almacenId === payload.almacenId,
+      );
+      const updatedStock = existingStock
+        ? inventario.stock.map((item): StockRegistro =>
+            item.id === existingStock.id
+              ? {
+                  ...item,
+                  stockDisponible: payload.stockDisponible,
+                  modoStock: payload.modoStock,
+                  ultimaActualizacion: new Date(now).toISOString(),
+                }
+              : item,
+          )
+        : [
+            ...inventario.stock,
+            {
+              id: `stock-${payload.productId}-${payload.almacenId}-${now}`,
+              productoId: payload.productId,
+              almacenId: payload.almacenId,
+              stockDisponible: payload.stockDisponible,
+              modoStock: payload.modoStock,
+              productosVinculadosIds: "[]",
+              ratiosConversion: "{}",
+              ultimaActualizacion: new Date(now).toISOString(),
+              visibleEnVentas: true,
+            },
+          ];
+
+      return {
+        ...workspace,
+        registro: {
+          ...workspace.registro,
+          inventario: {
+            ...inventario,
+            stock: updatedStock,
+          },
+        },
+      };
+    });
+
+    await persistProductLedger(
+      { ...ledger, workspaces: updatedWorkspaces },
+      "Inventario de producto actualizado",
+      "No se pudo actualizar el inventario",
+    );
   };
 
   const handleCreateWallet = async (payload: {
@@ -622,7 +798,10 @@ console.log(activeWorkspace?.accounting.monedas);
           <CatalogosView
             workspace={activeWorkspace}
             deletingProduct={Boolean(deletingProductId)}
+            savingProductChanges={savingProductChanges}
             onDeleteProduct={handleDeleteProduct}
+            onUpdateProductPrice={handleUpdateProductPrice}
+            onUpdateProductStock={handleUpdateProductStock}
           />
         );
       case "nomencladores":

--- a/client/src/gctcp/GC_TCP.tsx
+++ b/client/src/gctcp/GC_TCP.tsx
@@ -10,7 +10,7 @@ import { useToast } from "@/hooks/use-toast";
 import api from "@/lib/api";
 import { cn } from "@/lib/utils";
 import type { CatalogoCompra, CatalogoVenta, CloudLedgerContainer, HistorialPrecio, Moneda, MonedaTasa, MonedaTasaHistorial, StockRegistro, WalletMovimiento, WalletMovimientoTipo, WalletReferenciaTipo, WalletTipo } from "../accounting/core/types/accountingTypes";
-import { calculateWorkspaceAnalysis, formatLedgerDate } from "./accountingMath";
+import { calculateWorkspaceAnalysis, formatLedgerDate, formatMoney } from "./accountingMath";
 import { EmptyState, GcTcpSidebar } from "./components";
 import { DeleteWorkspaceDialog } from "./DeleteWorkspaceDialog";
 import { NomenclatorsView } from "./nomenclators/NomenclatorsView";
@@ -34,6 +34,14 @@ import DjGeneral from "./dj/General";
 import { useDjActions } from "./hooks/useDjActions";
 import EstadoResultadoView from "./views/EstadoResultadoView";
 import LibroDiarioView from "./libros/LibroDiarioView";
+
+type ProductLedgerToast = {
+  title: string;
+  description: string;
+};
+
+const formatProductQuantity = (value: number): string =>
+  value.toLocaleString("es-CU", { maximumFractionDigits: 2 });
 
 const GC_TCP: FC = () => {
   const navigate = useNavigate();
@@ -224,8 +232,8 @@ const GC_TCP: FC = () => {
     const usage = getProductUsage(activeWorkspace, productId);
     if (!usage.canDelete) {
       toast({
-        title: "Producto en uso",
-        description: `No se puede eliminar porque aparece en: ${usage.labels.join(", ")}.`,
+        title: "No se pudo eliminar desde Cuentas y Productos",
+        description: `El producto esta vinculado a ${usage.labels.join(", ")}. Revisa esos registros antes de eliminarlo del catalogo.`,
         variant: "destructive",
       });
       return;
@@ -266,13 +274,13 @@ const GC_TCP: FC = () => {
         current ? { ...current, registro: updatedLedger } : current,
       );
       toast({
-        title: "Producto eliminado",
-        description: `${product.nombre} fue eliminado del espacio activo.`,
+        title: "Producto eliminado de Cuentas y Productos",
+        description: `${product.nombre} ya no aparece en el catalogo del espacio activo.`,
       });
     } catch {
       toast({
-        title: "No se pudo eliminar",
-        description: "El producto no fue modificado.",
+        title: "No se pudo eliminar desde Cuentas y Productos",
+        description: `${product.nombre} no fue modificado. Intenta nuevamente desde el catalogo.`,
         variant: "destructive",
       });
     } finally {
@@ -281,7 +289,11 @@ const GC_TCP: FC = () => {
   };
 
 
-  const persistProductLedger = async (updatedLedger: CloudLedgerContainer, successTitle: string, failureTitle: string) => {
+  const persistProductLedger = async (
+    updatedLedger: CloudLedgerContainer,
+    successToast: ProductLedgerToast,
+    failureToast: ProductLedgerToast,
+  ) => {
     setSavingProductChanges(true);
     try {
       await api.put("/api/cont-ledger", {
@@ -291,9 +303,9 @@ const GC_TCP: FC = () => {
       setData((current) =>
         current ? { ...current, registro: updatedLedger } : current,
       );
-      toast({ title: successTitle });
+      toast(successToast);
     } catch {
-      toast({ title: failureTitle, variant: "destructive" });
+      toast({ ...failureToast, variant: "destructive" });
     } finally {
       setSavingProductChanges(false);
     }
@@ -392,8 +404,14 @@ const GC_TCP: FC = () => {
 
     await persistProductLedger(
       { ...ledger, workspaces: updatedWorkspaces },
-      "Precio de producto actualizado",
-      "No se pudo actualizar el precio",
+      {
+        title: "Precio actualizado en Cuentas y Productos",
+        description: `${product.nombre}: precio de ${payload.tipoPrecio === "VENTA" ? "venta" : "compra"} cambiado a ${formatMoney(payload.precio)}.`,
+      },
+      {
+        title: "No se pudo guardar el precio en Cuentas y Productos",
+        description: `${product.nombre} mantiene su precio anterior. Intenta nuevamente desde el catalogo.`,
+      },
     );
   };
 
@@ -402,6 +420,10 @@ const GC_TCP: FC = () => {
     const now = Date.now();
     const product = activeWorkspace.registro.inventario.productos.find((item) => item.id === payload.productId);
     if (!product) return;
+
+    const warehouseName = activeWorkspace.registro.inventario.almacenes.find(
+      (almacen) => almacen.id === payload.almacenId,
+    )?.nombre ?? payload.almacenId;
 
     const updatedWorkspaces = ledger.workspaces.map((workspace) => {
       if (workspace.id !== activeWorkspace.id) return workspace;
@@ -449,8 +471,14 @@ const GC_TCP: FC = () => {
 
     await persistProductLedger(
       { ...ledger, workspaces: updatedWorkspaces },
-      "Inventario de producto actualizado",
-      "No se pudo actualizar el inventario",
+      {
+        title: "Disponibilidad actualizada en Cuentas y Productos",
+        description: `${product.nombre}: ${formatProductQuantity(payload.stockDisponible)} ${product.unidad || "unidades"} en ${warehouseName} (${payload.modoStock.toLowerCase()}).`,
+      },
+      {
+        title: "No se pudo guardar la disponibilidad en Cuentas y Productos",
+        description: `${product.nombre} mantiene su cantidad anterior en ${warehouseName}. Intenta nuevamente desde el catalogo.`,
+      },
     );
   };
 

--- a/client/src/gctcp/accountingMath.ts
+++ b/client/src/gctcp/accountingMath.ts
@@ -3,11 +3,145 @@ import type {
 	DayAmountRow,
 	GeneralesData,
 	MonthCode,
+	MonthEntries,
+	RegistroAnualTCP,
 	RegistroTCP,
 	TributoRow,
 } from "../accounting/core/types/accountingTypes";
 import { MONTH_CODES, MONTH_NAMES } from "../accounting/core/utils/constants";
 import type { WorkspaceAnalysis } from "./types";
+
+
+export const normalizeLedgerYear = (value: number | string | null | undefined): number => {
+	const parsed = typeof value === "number" ? value : Number.parseInt(String(value ?? ""), 10);
+	return Number.isFinite(parsed) && parsed > 1900 ? parsed : new Date().getFullYear();
+};
+
+const createEmptyMonthRows = (year: number, key: "ingresos" | "gastos", month: MonthCode): DayAmountRow[] =>
+	Array.from({ length: 36 }, (_, index) => ({
+		id: `${key}-${year}-${month}-${index + 1}`,
+		dia: "",
+		importe: "",
+	}));
+
+export const createEmptyMonthEntries = (year: number, key: "ingresos" | "gastos"): MonthEntries =>
+	MONTH_CODES.reduce((entries, month) => ({
+		...entries,
+		[month]: createEmptyMonthRows(year, key, month),
+	}), {} as MonthEntries);
+
+export const createEmptyTributoRows = (): TributoRow[] =>
+	MONTH_NAMES.map((mes) => ({
+		mes,
+		ventas: "",
+		fuerza: "",
+		sellos: "",
+		anuncios: "",
+		css20: "",
+		css14: "",
+		otros: "",
+		restauracion: "",
+		arrendamiento: "",
+		exonerado: "",
+		otrosMFP: "",
+		cuotaMensual: "",
+	}));
+
+export const createEmptyAnnualRegistro = (year: number): RegistroAnualTCP => ({
+	ingresos: createEmptyMonthEntries(year, "ingresos"),
+	gastos: createEmptyMonthEntries(year, "gastos"),
+	tributos: createEmptyTributoRows(),
+});
+
+export const getRegistroAnnualData = (registro: RegistroTCP, year: number): RegistroAnualTCP => {
+	const normalizedYear = normalizeLedgerYear(year);
+	const yearKey = String(normalizedYear);
+	const annualData = registro.registrosPorAnio?.[yearKey];
+	if (annualData) return annualData;
+
+	const rootYear = normalizeLedgerYear(registro.generales?.anio);
+	if (rootYear === normalizedYear) {
+		return {
+			ingresos: registro.ingresos,
+			gastos: registro.gastos,
+			tributos: registro.tributos,
+		};
+	}
+
+	return createEmptyAnnualRegistro(normalizedYear);
+};
+
+export const getWorkspaceForYear = (workspace: CloudWorkspaceEntry, year: number): CloudWorkspaceEntry => {
+	const normalizedYear = normalizeLedgerYear(year);
+	const annualData = getRegistroAnnualData(workspace.registro, normalizedYear);
+	return {
+		...workspace,
+		registro: {
+			...workspace.registro,
+			generales: {
+				...workspace.registro.generales,
+				anio: normalizedYear,
+			},
+			ingresos: annualData.ingresos,
+			gastos: annualData.gastos,
+			tributos: annualData.tributos,
+		},
+	};
+};
+
+export const ensureRegistroYear = (registro: RegistroTCP, year: number): RegistroTCP => {
+	const normalizedYear = normalizeLedgerYear(year);
+	const rootYear = normalizeLedgerYear(registro.generales?.anio);
+	const currentYears = registro.registrosPorAnio ?? {};
+	const yearsWithRoot = currentYears[String(rootYear)]
+		? currentYears
+		: {
+				...currentYears,
+				[String(rootYear)]: {
+					ingresos: registro.ingresos,
+					gastos: registro.gastos,
+					tributos: registro.tributos,
+				},
+			};
+	const selectedAnnualData = yearsWithRoot[String(normalizedYear)] ?? createEmptyAnnualRegistro(normalizedYear);
+	const nextYears = {
+		...yearsWithRoot,
+		[String(normalizedYear)]: selectedAnnualData,
+	};
+
+	return {
+		...registro,
+		generales: {
+			...registro.generales,
+			anio: normalizedYear,
+		},
+		ingresos: selectedAnnualData.ingresos,
+		gastos: selectedAnnualData.gastos,
+		tributos: selectedAnnualData.tributos,
+		registrosPorAnio: nextYears,
+	};
+};
+
+export const getWorkspaceYears = (workspace: CloudWorkspaceEntry | null): number[] => {
+	const yearSet = new Set<number>();
+	const currentYear = new Date().getFullYear();
+	yearSet.add(currentYear);
+	yearSet.add(currentYear - 1);
+	yearSet.add(currentYear + 1);
+
+	if (workspace) {
+		yearSet.add(normalizeLedgerYear(workspace.registro.generales?.anio));
+		Object.keys(workspace.registro.registrosPorAnio ?? {}).forEach((yearKey) => {
+			yearSet.add(normalizeLedgerYear(yearKey));
+		});
+		workspace.registro.inventario.operaciones.forEach((operation) => {
+			const operationYear = Number.parseInt(operation.fecha.slice(0, 4), 10);
+			if (Number.isFinite(operationYear)) yearSet.add(operationYear);
+		});
+	}
+
+	return Array.from(yearSet).sort((a, b) => b - a);
+};
 
 export const EMPTY_GENERALES: GeneralesData = {
 	nombre: "",

--- a/client/src/gctcp/dj/General.tsx
+++ b/client/src/gctcp/dj/General.tsx
@@ -1,7 +1,7 @@
 import { CloudWorkspaceEntry, GeneralesData } from "@/accounting/core/types/accountingTypes";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Edit2, WalletCards } from "lucide-react";
-import { useState, type FC } from "react";
+import { useEffect, useState, type FC } from "react";
 import { EMPTY_GENERALES } from "../accountingMath";
 import { MetricCard } from "../components";
 import { WorkspaceAnalysis } from "../types";
@@ -38,7 +38,6 @@ const DjGeneral: FC<{
 
   const [nombre, setNombre] = useState(generales.nombre);
   const [nit, setNit] = useState(generales.nit);
-  const [anio, setAnio] = useState(generales.anio);
 
   const [legalProvincia, setLegalProvincia] = useState(
     generales.legalProvincia,
@@ -58,6 +57,19 @@ const DjGeneral: FC<{
 
   const [actividad, setActividad] = useState(generales.actividad);
   const [codigo, setCodigo] = useState(generales.codigo);
+
+  useEffect(() => {
+    setNombre(generales.nombre);
+    setNit(generales.nit);
+    setLegalProvincia(generales.legalProvincia);
+    setLegalMunicipio(generales.legalMunicipio);
+    setLegalCalle(generales.legalCalle);
+    setFiscalProvincia(generales.fiscalProvincia);
+    setFiscalMunicipio(generales.fiscalMunicipio);
+    setFiscalCalle(generales.fiscalCalle);
+    setActividad(generales.actividad);
+    setCodigo(generales.codigo);
+  }, [generales]);
 
   const fiscalAddress = [
     generales.fiscalCalle,
@@ -129,9 +141,13 @@ const DjGeneral: FC<{
                     <Input
                       id="anio"
                       placeholder="Año"
-                      value={anio}
-                      onChange={(e) => setAnio(Number.parseInt(e.target.value))}
+                      value={generales.anio}
+                      disabled
+                      readOnly
                     />
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      Se actualiza desde el selector de año fiscal.
+                    </p>
                   </div>
                 </div>
 
@@ -296,7 +312,7 @@ const DjGeneral: FC<{
                   onClick={() => {
                     onSave?.({
                       nombre,
-                      anio,
+                      anio: generales.anio,
                       nit,
                       actividad,
                       codigo,

--- a/client/src/gctcp/pos/PointOfSaleView.tsx
+++ b/client/src/gctcp/pos/PointOfSaleView.tsx
@@ -18,21 +18,21 @@ const posSections: Array<{
 	{ id: "mas", label: "Mas", icon: <MoreHorizontal /> },
 ];
 
-export const PointOfSaleView: FC<{ workspace: CloudWorkspaceEntry }> = ({ workspace }) => {
+export const PointOfSaleView: FC<{ workspace: CloudWorkspaceEntry; selectedYear: number }> = ({ workspace, selectedYear }) => {
 	const [section, setSection] = useState<PosSection>("venta");
 
 	const renderSection = () => {
 		switch (section) {
 			case "venta":
-				return <SaleSection workspace={workspace} />;
+				return <SaleSection workspace={workspace} selectedYear={selectedYear} />;
 			case "compra":
-				return <PurchaseSection workspace={workspace} />;
+				return <PurchaseSection workspace={workspace} selectedYear={selectedYear} />;
 			case "almacen":
-				return <WarehouseSection workspace={workspace} />;
+				return <WarehouseSection workspace={workspace} selectedYear={selectedYear} />;
 			case "historial":
-				return <HistorySection workspace={workspace} />;
+				return <HistorySection workspace={workspace} selectedYear={selectedYear} />;
 			case "mas":
-				return <MoreSection workspace={workspace} />;
+				return <MoreSection workspace={workspace} selectedYear={selectedYear} />;
 			default:
 				return null;
 		}

--- a/client/src/gctcp/pos/sections.tsx
+++ b/client/src/gctcp/pos/sections.tsx
@@ -10,7 +10,11 @@ import { findProduct, formatStock, getVisibleStock, getWarehouseName } from "./p
 
 type WorkspaceSectionProps = {
 	workspace: CloudWorkspaceEntry;
+	selectedYear: number;
 };
+
+const operationMatchesYear = (fecha: string, selectedYear: number): boolean =>
+	Number.parseInt(fecha.slice(0, 4), 10) === selectedYear;
 
 const ProductCard: FC<{
 	name: string;
@@ -32,13 +36,13 @@ const ProductCard: FC<{
 	</Card>
 );
 
-export const SaleSection: FC<WorkspaceSectionProps> = ({ workspace }) => {
+export const SaleSection: FC<WorkspaceSectionProps> = ({ workspace, selectedYear }) => {
 	const { inventario } = workspace.registro;
 	const catalogItems = inventario.catalogoVentas
 		.filter((item) => item.activo)
 		.map((item) => ({ catalog: item, product: findProduct(workspace, item.productoId) }))
 		.filter((item) => item.product);
-	const sales = inventario.operaciones.filter((operation) => operation.tipo === "venta" && !operation.anulada);
+	const sales = inventario.operaciones.filter((operation) => operation.tipo === "venta" && !operation.anulada && operationMatchesYear(operation.fecha, selectedYear));
 	const salesTotal = sales.reduce((total, operation) => total + operation.total, 0);
 
 	return (
@@ -46,7 +50,7 @@ export const SaleSection: FC<WorkspaceSectionProps> = ({ workspace }) => {
 			<div className="grid gap-4 md:grid-cols-3">
 				<PosSummary title="Catalogo de ventas" value={String(catalogItems.length)} detail="Productos activos para vender" icon={<ShoppingCart />} />
 				<PosSummary title="Ventas registradas" value={String(sales.length)} detail="Operaciones no anuladas" icon={<ReceiptText />} />
-				<PosSummary title="Total vendido" value={formatMoney(salesTotal)} detail="Historico del espacio" icon={<TrendingUp />} />
+				<PosSummary title="Total vendido" value={formatMoney(salesTotal)} detail={`Año ${selectedYear}`} icon={<TrendingUp />} />
 			</div>
 			<div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
 				{catalogItems.map(({ catalog, product }) => (
@@ -64,13 +68,13 @@ export const SaleSection: FC<WorkspaceSectionProps> = ({ workspace }) => {
 	);
 };
 
-export const PurchaseSection: FC<WorkspaceSectionProps> = ({ workspace }) => {
+export const PurchaseSection: FC<WorkspaceSectionProps> = ({ workspace, selectedYear }) => {
 	const { inventario } = workspace.registro;
 	const catalogItems = inventario.catalogoCompras
 		.filter((item) => item.activo)
 		.map((item) => ({ catalog: item, product: findProduct(workspace, item.productoId) }))
 		.filter((item) => item.product);
-	const purchases = inventario.operaciones.filter((operation) => operation.tipo === "compra" && !operation.anulada);
+	const purchases = inventario.operaciones.filter((operation) => operation.tipo === "compra" && !operation.anulada && operationMatchesYear(operation.fecha, selectedYear));
 	const purchasesTotal = purchases.reduce((total, operation) => total + operation.total, 0);
 
 	return (
@@ -78,7 +82,7 @@ export const PurchaseSection: FC<WorkspaceSectionProps> = ({ workspace }) => {
 			<div className="grid gap-4 md:grid-cols-3">
 				<PosSummary title="Catalogo de compras" value={String(catalogItems.length)} detail="Insumos activos" icon={<Package />} />
 				<PosSummary title="Compras registradas" value={String(purchases.length)} detail="Operaciones no anuladas" icon={<ReceiptText />} />
-				<PosSummary title="Total comprado" value={formatMoney(purchasesTotal)} detail="Historico del espacio" icon={<TrendingDown />} />
+				<PosSummary title="Total comprado" value={formatMoney(purchasesTotal)} detail={`Año ${selectedYear}`} icon={<TrendingDown />} />
 			</div>
 			<div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
 				{catalogItems.map(({ catalog, product }) => (
@@ -96,7 +100,7 @@ export const PurchaseSection: FC<WorkspaceSectionProps> = ({ workspace }) => {
 	);
 };
 
-export const WarehouseSection: FC<WorkspaceSectionProps> = ({ workspace }) => {
+export const WarehouseSection: FC<WorkspaceSectionProps> = ({ workspace, selectedYear }) => {
 	const { inventario } = workspace.registro;
 	const visibleStock = getVisibleStock(inventario.stock);
 
@@ -105,7 +109,7 @@ export const WarehouseSection: FC<WorkspaceSectionProps> = ({ workspace }) => {
 			<div className="grid gap-4 md:grid-cols-3">
 				<PosSummary title="Almacenes" value={String(inventario.almacenes.length)} detail="Espacios de inventario" icon={<Warehouse />} />
 				<PosSummary title="Items en stock" value={String(visibleStock.length)} detail="Disponibles o visibles en venta" icon={<Boxes />} />
-				<PosSummary title="Movimientos" value={String(inventario.movimientos.length)} detail="Entradas, salidas y ajustes" icon={<ReceiptText />} />
+				<PosSummary title="Movimientos" value={String(inventario.movimientos.filter((movement) => operationMatchesYear(movement.fecha, selectedYear)).length)} detail={`Entradas, salidas y ajustes ${selectedYear}`} icon={<ReceiptText />} />
 			</div>
 			<Card className="rounded-lg shadow-sm">
 				<CardHeader className="p-4">
@@ -143,21 +147,23 @@ export const WarehouseSection: FC<WorkspaceSectionProps> = ({ workspace }) => {
 	);
 };
 
-export const HistorySection: FC<WorkspaceSectionProps> = ({ workspace }) => {
-	const operations = [...workspace.registro.inventario.operaciones].reverse();
+export const HistorySection: FC<WorkspaceSectionProps> = ({ workspace, selectedYear }) => {
+	const operations = workspace.registro.inventario.operaciones
+		.filter((operation) => operationMatchesYear(operation.fecha, selectedYear))
+		.reverse();
 	const salesTotal = operations.filter((operation) => operation.tipo === "venta").reduce((total, operation) => total + operation.total, 0);
 	const purchasesTotal = operations.filter((operation) => operation.tipo === "compra").reduce((total, operation) => total + operation.total, 0);
 
 	return (
 		<div className="space-y-4">
 			<div className="grid gap-4 md:grid-cols-3">
-				<PosSummary title="Operaciones" value={String(operations.length)} detail="Compras y ventas" icon={<ReceiptText />} />
-				<PosSummary title="Ventas" value={formatMoney(salesTotal)} detail="Total historico" icon={<TrendingUp />} />
-				<PosSummary title="Compras" value={formatMoney(purchasesTotal)} detail="Total historico" icon={<TrendingDown />} />
+				<PosSummary title="Operaciones" value={String(operations.length)} detail={`Compras y ventas ${selectedYear}`} icon={<ReceiptText />} />
+				<PosSummary title="Ventas" value={formatMoney(salesTotal)} detail={`Total ${selectedYear}`} icon={<TrendingUp />} />
+				<PosSummary title="Compras" value={formatMoney(purchasesTotal)} detail={`Total ${selectedYear}`} icon={<TrendingDown />} />
 			</div>
 			<Card className="rounded-lg shadow-sm">
 				<CardHeader className="p-4">
-					<CardTitle className="text-base">Historial reciente</CardTitle>
+					<CardTitle className="text-base">Historial reciente de {selectedYear}</CardTitle>
 				</CardHeader>
 				<CardContent className="space-y-2 p-4 pt-0">
 					{operations.slice(0, 20).map((operation) => (
@@ -181,17 +187,18 @@ export const HistorySection: FC<WorkspaceSectionProps> = ({ workspace }) => {
 	);
 };
 
-export const MoreSection: FC<WorkspaceSectionProps> = ({ workspace }) => {
+export const MoreSection: FC<WorkspaceSectionProps> = ({ workspace, selectedYear }) => {
 	const { inventario } = workspace.registro;
-	const salesTotal = inventario.operaciones.filter((operation) => operation.tipo === "venta").reduce((total, operation) => total + operation.total, 0);
-	const purchasesTotal = inventario.operaciones.filter((operation) => operation.tipo === "compra").reduce((total, operation) => total + operation.total, 0);
+	const operationsForYear = inventario.operaciones.filter((operation) => operationMatchesYear(operation.fecha, selectedYear));
+	const salesTotal = operationsForYear.filter((operation) => operation.tipo === "venta").reduce((total, operation) => total + operation.total, 0);
+	const purchasesTotal = operationsForYear.filter((operation) => operation.tipo === "compra").reduce((total, operation) => total + operation.total, 0);
 	const balance = salesTotal - purchasesTotal;
 
 	return (
 		<div className="grid gap-4 xl:grid-cols-2">
 			<Card className="rounded-lg shadow-sm">
 				<CardHeader className="p-4">
-					<CardTitle className="text-base">Resumen rapido</CardTitle>
+					<CardTitle className="text-base">Resumen rapido de {selectedYear}</CardTitle>
 				</CardHeader>
 				<CardContent className="space-y-3 p-4 pt-0 text-sm">
 					<div className="flex justify-between gap-3"><span>Ventas</span><strong>{formatMoney(salesTotal)}</strong></div>

--- a/client/src/gctcp/products/ProductCatalogPanel.tsx
+++ b/client/src/gctcp/products/ProductCatalogPanel.tsx
@@ -1,5 +1,5 @@
 import { type FC, useMemo, useState } from "react";
-import { Boxes, ShoppingBag, ShoppingCart, Trash2, Warehouse } from "lucide-react";
+import { Boxes, Pencil, ShoppingBag, ShoppingCart, Trash2, Warehouse } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -7,8 +7,16 @@ import type { CloudWorkspaceEntry, ProductoInventario } from "../../accounting/c
 import { EmptyState } from "../components";
 import { DeleteProductDialog } from "./DeleteProductDialog";
 import {
+	ProductPriceDialog,
+	ProductStockDialog,
+	type ProductPriceType,
+	type ProductPriceUpdate,
+	type ProductStockUpdate,
+} from "./ProductEditDialogs";
+import {
 	getProductAvailability,
 	getProductPricing,
+	getProductStockItems,
 	getProductSubtitle,
 	getProductUsage,
 } from "./productUtils";
@@ -16,10 +24,15 @@ import {
 export const ProductCatalogPanel: FC<{
 	workspace: CloudWorkspaceEntry;
 	deletingProduct: boolean;
+	savingProductChanges: boolean;
 	onDeleteProduct: (productId: string) => void;
-}> = ({ workspace, deletingProduct, onDeleteProduct }) => {
+	onUpdateProductPrice: (payload: ProductPriceUpdate) => void;
+	onUpdateProductStock: (payload: ProductStockUpdate) => void;
+}> = ({ workspace, deletingProduct, savingProductChanges, onDeleteProduct, onUpdateProductPrice, onUpdateProductStock }) => {
 	const productos = workspace.registro.inventario.productos;
 	const [productToDelete, setProductToDelete] = useState<ProductoInventario | null>(null);
+	const [priceEditor, setPriceEditor] = useState<{ product: ProductoInventario; priceType: ProductPriceType; currentPrice: number | null } | null>(null);
+	const [stockEditorProduct, setStockEditorProduct] = useState<ProductoInventario | null>(null);
 	const selectedUsage = useMemo(
 		() => productToDelete ? getProductUsage(workspace, productToDelete.id) : null,
 		[productToDelete, workspace],
@@ -27,6 +40,35 @@ export const ProductCatalogPanel: FC<{
 
 	return (
 		<Card className="rounded-lg shadow-sm">
+
+			<ProductPriceDialog
+				product={priceEditor?.product ?? null}
+				priceType={priceEditor?.priceType ?? null}
+				currentPrice={priceEditor?.currentPrice ?? null}
+				open={Boolean(priceEditor)}
+				saving={savingProductChanges}
+				onOpenChange={(open) => {
+					if (!open && !savingProductChanges) setPriceEditor(null);
+				}}
+				onSave={(payload) => {
+					onUpdateProductPrice(payload);
+					setPriceEditor(null);
+				}}
+			/>
+			<ProductStockDialog
+				product={stockEditorProduct}
+				almacenes={workspace.registro.inventario.almacenes}
+				stockItems={stockEditorProduct ? workspace.registro.inventario.stock.filter((item) => item.productoId === stockEditorProduct.id) : []}
+				open={Boolean(stockEditorProduct)}
+				saving={savingProductChanges}
+				onOpenChange={(open) => {
+					if (!open && !savingProductChanges) setStockEditorProduct(null);
+				}}
+				onSave={(payload) => {
+					onUpdateProductStock(payload);
+					setStockEditorProduct(null);
+				}}
+			/>
 			<DeleteProductDialog
 				product={productToDelete}
 				open={Boolean(productToDelete)}
@@ -48,6 +90,7 @@ export const ProductCatalogPanel: FC<{
 					const usage = getProductUsage(workspace, product.id);
 					const availability = getProductAvailability(workspace, product.id);
 					const pricing = getProductPricing(workspace, product.id);
+					const stockDetails = getProductStockItems(workspace, product.id);
 
 					return (
 						<div key={product.id} className="rounded-md border border-slate-200 p-3 dark:border-slate-800">
@@ -72,24 +115,51 @@ export const ProductCatalogPanel: FC<{
 
 							<div className="mt-3 grid gap-2 text-sm sm:grid-cols-3">
 								<div className="rounded-md bg-slate-100 p-3 dark:bg-slate-800">
-									<div className="flex items-center gap-2 text-xs uppercase text-slate-500 dark:text-slate-400">
-										<Warehouse className="size-3.5" />
-										Disponibilidad
+									<div className="flex items-center justify-between gap-2 text-xs uppercase text-slate-500 dark:text-slate-400">
+										<span className="flex items-center gap-2">
+											<Warehouse className="size-3.5" />
+											Disponibilidad
+										</span>
+										<Button
+											type="button"
+											variant="ghost"
+											size="sm"
+											className="h-7 px-2 text-xs"
+											disabled={savingProductChanges}
+											onClick={() => setStockEditorProduct(product)}
+										>
+											<Pencil className="size-3.5" />
+											Modificar
+										</Button>
 									</div>
 									<p className="mt-1 font-semibold text-slate-950 dark:text-slate-50">{availability.label}</p>
 									<p className="text-xs text-slate-500 dark:text-slate-400">{availability.detail}</p>
+									{stockDetails.length > 0 && (
+										<div className="mt-2 space-y-1 border-t border-slate-200 pt-2 text-xs dark:border-slate-700">
+											{stockDetails.map((item) => (
+												<div key={item.stock.id} className="flex items-center justify-between gap-2">
+													<span className="break-words text-slate-600 dark:text-slate-300">{item.warehouseName}</span>
+													<span className="shrink-0 font-medium text-slate-950 dark:text-slate-50">{item.quantityLabel}</span>
+												</div>
+											))}
+										</div>
+									)}
 								</div>
 								<div className="rounded-md bg-slate-100 p-3 dark:bg-slate-800">
-									<div className="flex items-center gap-2 text-xs uppercase text-slate-500 dark:text-slate-400">
-										<ShoppingCart className="size-3.5" />
-										Precio venta
+									<div className="flex items-center justify-between gap-2 text-xs uppercase text-slate-500 dark:text-slate-400">
+										<span className="flex items-center gap-2"><ShoppingCart className="size-3.5" />Precio venta</span>
+										<Button type="button" variant="ghost" size="icon" className="size-7" disabled={savingProductChanges} onClick={() => setPriceEditor({ product, priceType: "VENTA", currentPrice: pricing.salePriceValue })} title="Editar precio de venta">
+											<Pencil className="size-3.5" />
+										</Button>
 									</div>
 									<p className="mt-1 font-semibold text-slate-950 dark:text-slate-50">{pricing.salePrice}</p>
 								</div>
 								<div className="rounded-md bg-slate-100 p-3 dark:bg-slate-800">
-									<div className="flex items-center gap-2 text-xs uppercase text-slate-500 dark:text-slate-400">
-										<ShoppingBag className="size-3.5" />
-										Precio compra
+									<div className="flex items-center justify-between gap-2 text-xs uppercase text-slate-500 dark:text-slate-400">
+										<span className="flex items-center gap-2"><ShoppingBag className="size-3.5" />Precio compra</span>
+										<Button type="button" variant="ghost" size="icon" className="size-7" disabled={savingProductChanges} onClick={() => setPriceEditor({ product, priceType: "COMPRA", currentPrice: pricing.purchasePriceValue })} title="Editar precio de compra">
+											<Pencil className="size-3.5" />
+										</Button>
 									</div>
 									<p className="mt-1 font-semibold text-slate-950 dark:text-slate-50">{pricing.purchasePrice}</p>
 								</div>

--- a/client/src/gctcp/products/ProductEditDialogs.tsx
+++ b/client/src/gctcp/products/ProductEditDialogs.tsx
@@ -1,0 +1,239 @@
+import { type FC, useEffect, useMemo, useState } from "react";
+import { Boxes, CircleDollarSign } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import type { Almacen, ProductoInventario, StockRegistro } from "../../accounting/core/types/accountingTypes";
+import { formatMoney } from "../accountingMath";
+
+export type ProductPriceType = "VENTA" | "COMPRA";
+
+export type ProductPriceUpdate = {
+	productId: string;
+	tipoPrecio: ProductPriceType;
+	precio: number;
+};
+
+export type ProductStockUpdate = {
+	productId: string;
+	almacenId: string;
+	stockDisponible: number;
+	modoStock: StockRegistro["modoStock"];
+};
+
+const parsePositiveNumber = (value: string): number | null => {
+	const normalized = value.replace(",", ".").trim();
+	if (!normalized) return null;
+	const numberValue = Number(normalized);
+	return Number.isFinite(numberValue) && numberValue >= 0 ? numberValue : null;
+};
+
+export const ProductPriceDialog: FC<{
+	product: ProductoInventario | null;
+	priceType: ProductPriceType | null;
+	currentPrice: number | null;
+	open: boolean;
+	saving: boolean;
+	onOpenChange: (open: boolean) => void;
+	onSave: (payload: ProductPriceUpdate) => void;
+}> = ({ product, priceType, currentPrice, open, saving, onOpenChange, onSave }) => {
+	const [price, setPrice] = useState("");
+	const parsedPrice = parsePositiveNumber(price);
+	const canSave = Boolean(product && priceType && parsedPrice !== null && !saving);
+	const title = priceType === "COMPRA" ? "Editar precio de compra" : "Editar precio de venta";
+
+	useEffect(() => {
+		if (!open) return;
+		setPrice(currentPrice !== null && Number.isFinite(currentPrice) ? String(currentPrice) : "");
+	}, [currentPrice, open]);
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent>
+				<DialogHeader>
+					<div className="flex items-center gap-3">
+						<div className="flex size-10 shrink-0 items-center justify-center rounded-md bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-300">
+							<CircleDollarSign className="size-5" />
+						</div>
+						<div>
+							<DialogTitle>{title}</DialogTitle>
+							<DialogDescription>
+								Actualiza el precio vigente de {product?.nombre ?? "este producto"} en el catalogo.
+							</DialogDescription>
+						</div>
+					</div>
+				</DialogHeader>
+
+				<div className="space-y-2">
+					<Label htmlFor="product-price">Nuevo precio</Label>
+					<Input
+						id="product-price"
+						type="number"
+						min="0"
+						step="0.01"
+						value={price}
+						onChange={(event) => setPrice(event.target.value)}
+						placeholder="0.00"
+						disabled={saving}
+					/>
+					<p className="text-xs text-slate-500 dark:text-slate-400">
+						Precio actual: {currentPrice !== null ? formatMoney(currentPrice) : "No disponible"}.
+					</p>
+				</div>
+
+				<DialogFooter>
+					<Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
+						Cancelar
+					</Button>
+					<Button
+						type="button"
+						disabled={!canSave}
+						onClick={() => {
+							if (!product || !priceType || parsedPrice === null) return;
+							onSave({ productId: product.id, tipoPrecio: priceType, precio: parsedPrice });
+						}}
+					>
+						{saving ? "Guardando..." : "Guardar precio"}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+};
+
+export const ProductStockDialog: FC<{
+	product: ProductoInventario | null;
+	almacenes: Almacen[];
+	stockItems: StockRegistro[];
+	open: boolean;
+	saving: boolean;
+	onOpenChange: (open: boolean) => void;
+	onSave: (payload: ProductStockUpdate) => void;
+}> = ({ product, almacenes, stockItems, open, saving, onOpenChange, onSave }) => {
+	const firstStock = stockItems[0] ?? null;
+	const firstWarehouse = almacenes[0] ?? null;
+	const [almacenId, setAlmacenId] = useState("");
+	const [stockDisponible, setStockDisponible] = useState("");
+	const [modoStock, setModoStock] = useState<StockRegistro["modoStock"]>("MANUAL");
+	const parsedStock = parsePositiveNumber(stockDisponible);
+	const selectedStock = useMemo(
+		() => stockItems.find((item) => item.almacenId === almacenId) ?? null,
+		[almacenId, stockItems],
+	);
+	const canSave = Boolean(product && almacenId && parsedStock !== null && !saving);
+
+	useEffect(() => {
+		if (!open) return;
+		const initialStock = firstStock;
+		const initialWarehouseId = initialStock?.almacenId ?? firstWarehouse?.id ?? "";
+		setAlmacenId(initialWarehouseId);
+		setStockDisponible(initialStock ? String(initialStock.stockDisponible) : "0");
+		setModoStock(initialStock?.modoStock ?? "MANUAL");
+	}, [firstStock, firstWarehouse, open]);
+
+	useEffect(() => {
+		if (!open || !selectedStock) return;
+		setStockDisponible(String(selectedStock.stockDisponible));
+		setModoStock(selectedStock.modoStock);
+	}, [open, selectedStock]);
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent>
+				<DialogHeader>
+					<div className="flex items-center gap-3">
+						<div className="flex size-10 shrink-0 items-center justify-center rounded-md bg-sky-100 text-sky-700 dark:bg-sky-500/15 dark:text-sky-300">
+							<Boxes className="size-5" />
+						</div>
+						<div>
+							<DialogTitle>Modificar inventario</DialogTitle>
+							<DialogDescription>
+								Actualiza la disponibilidad de {product?.nombre ?? "este producto"} por almacen.
+							</DialogDescription>
+						</div>
+					</div>
+				</DialogHeader>
+
+				<div className="grid gap-4 sm:grid-cols-2">
+					<div className="space-y-2 sm:col-span-2">
+						<Label>Almacen</Label>
+						<Select value={almacenId} onValueChange={setAlmacenId} disabled={saving || almacenes.length === 0}>
+							<SelectTrigger>
+								<SelectValue placeholder="Selecciona un almacen" />
+							</SelectTrigger>
+							<SelectContent>
+								{almacenes.map((almacen) => (
+									<SelectItem key={almacen.id} value={almacen.id}>
+										{almacen.nombre}{almacen.principal ? " (principal)" : ""}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+					<div className="space-y-2">
+						<Label htmlFor="product-stock">Cantidad disponible</Label>
+						<Input
+							id="product-stock"
+							type="number"
+							min="0"
+							step="0.01"
+							value={stockDisponible}
+							onChange={(event) => setStockDisponible(event.target.value)}
+							placeholder="0"
+							disabled={saving}
+						/>
+					</div>
+					<div className="space-y-2">
+						<Label>Modo</Label>
+						<Select value={modoStock} onValueChange={(value: StockRegistro["modoStock"]) => setModoStock(value)} disabled={saving}>
+							<SelectTrigger>
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="MANUAL">Manual</SelectItem>
+								<SelectItem value="ILIMITADO">Ilimitado</SelectItem>
+								<SelectItem value="VINCULADO">Vinculado</SelectItem>
+							</SelectContent>
+						</Select>
+					</div>
+					{almacenes.length === 0 && (
+						<p className="text-sm text-red-600 dark:text-red-400 sm:col-span-2">
+							No hay almacenes disponibles para registrar inventario.
+						</p>
+					)}
+				</div>
+
+				<DialogFooter>
+					<Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
+						Cancelar
+					</Button>
+					<Button
+						type="button"
+						disabled={!canSave}
+						onClick={() => {
+							if (!product || parsedStock === null) return;
+							onSave({ productId: product.id, almacenId, stockDisponible: parsedStock, modoStock });
+						}}
+					>
+						{saving ? "Guardando..." : "Guardar inventario"}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+};

--- a/client/src/gctcp/products/productUtils.ts
+++ b/client/src/gctcp/products/productUtils.ts
@@ -1,4 +1,4 @@
-import type { CloudWorkspaceEntry, ProductoInventario } from "../../accounting/core/types/accountingTypes";
+import type { CloudWorkspaceEntry, ProductoInventario, StockRegistro } from "../../accounting/core/types/accountingTypes";
 import { formatMoney } from "../accountingMath";
 
 export type ProductUsage = {
@@ -14,6 +14,14 @@ export type ProductAvailability = {
 export type ProductPricing = {
 	salePrice: string;
 	purchasePrice: string;
+	salePriceValue: number | null;
+	purchasePriceValue: number | null;
+};
+
+export type ProductAvailabilityItem = {
+	stock: StockRegistro;
+	warehouseName: string;
+	quantityLabel: string;
 };
 
 const containsProductId = (value: unknown, productId: string): boolean => {
@@ -54,6 +62,19 @@ export const getProductUsage = (workspace: CloudWorkspaceEntry, productId: strin
 	};
 };
 
+export const getProductStockItems = (workspace: CloudWorkspaceEntry, productId: string): ProductAvailabilityItem[] => {
+	const { inventario } = workspace.registro;
+	return inventario.stock
+		.filter((item) => item.productoId === productId)
+		.map((stock) => ({
+			stock,
+			warehouseName: inventario.almacenes.find((almacen) => almacen.id === stock.almacenId)?.nombre ?? stock.almacenId,
+			quantityLabel: stock.modoStock === "ILIMITADO"
+				? "Ilimitado"
+				: stock.stockDisponible.toLocaleString("es-CU", { maximumFractionDigits: 2 }),
+		}));
+};
+
 export const getProductAvailability = (workspace: CloudWorkspaceEntry, productId: string): ProductAvailability => {
 	const stockItems = workspace.registro.inventario.stock.filter((item) => item.productoId === productId);
 	if (stockItems.length === 0) {
@@ -70,28 +91,38 @@ export const getProductAvailability = (workspace: CloudWorkspaceEntry, productId
 	};
 };
 
-const summarizePrices = (prices: number[]): string => {
+const getPriceSummary = (prices: number[]): { label: string; value: number | null } => {
 	const validPrices = prices.filter((price) => Number.isFinite(price));
-	if (validPrices.length === 0) return "No disponible";
+	if (validPrices.length === 0) return { label: "No disponible", value: null };
 	const min = Math.min(...validPrices);
 	const max = Math.max(...validPrices);
-	if (min === max) return formatMoney(min);
-	return `${formatMoney(min)} - ${formatMoney(max)}`;
+	return {
+		label: min === max ? formatMoney(min) : `${formatMoney(min)} - ${formatMoney(max)}`,
+		value: validPrices[validPrices.length - 1] ?? null,
+	};
 };
 
 export const getProductPricing = (workspace: CloudWorkspaceEntry, productId: string): ProductPricing => {
 	const { inventario } = workspace.registro;
+	const saleCatalogPrices = inventario.catalogoVentas
+		.filter((item) => item.productoId === productId && item.activo)
+		.map((item) => item.precioReferencia);
+	const purchaseCatalogPrices = inventario.catalogoCompras
+		.filter((item) => item.productoId === productId && item.activo)
+		.map((item) => item.precioReferencia);
+	const saleHistoryPrices = inventario.historialPrecios
+		.filter((item) => item.productoId === productId && item.tipoPrecio === "VENTA" && item.activo)
+		.map((item) => item.precio);
+	const purchaseHistoryPrices = inventario.historialPrecios
+		.filter((item) => item.productoId === productId && item.tipoPrecio === "COMPRA" && item.activo)
+		.map((item) => item.precio);
+	const salePrice = getPriceSummary(saleCatalogPrices.length > 0 ? saleCatalogPrices : saleHistoryPrices);
+	const purchasePrice = getPriceSummary(purchaseCatalogPrices.length > 0 ? purchaseCatalogPrices : purchaseHistoryPrices);
 	return {
-		salePrice: summarizePrices(
-			inventario.catalogoVentas
-				.filter((item) => item.productoId === productId && item.activo)
-				.map((item) => item.precioReferencia),
-		),
-		purchasePrice: summarizePrices(
-			inventario.catalogoCompras
-				.filter((item) => item.productoId === productId && item.activo)
-				.map((item) => item.precioReferencia),
-		),
+		salePrice: salePrice.label,
+		purchasePrice: purchasePrice.label,
+		salePriceValue: salePrice.value,
+		purchasePriceValue: purchasePrice.value,
 	};
 };
 

--- a/client/src/gctcp/views.tsx
+++ b/client/src/gctcp/views.tsx
@@ -41,6 +41,7 @@ import {
 } from "./accountingMath";
 import { EmptyState, MetricCard, WorkspaceSelector } from "./components";
 import { ProductCatalogPanel } from "./products/ProductCatalogPanel";
+import type { ProductPriceUpdate, ProductStockUpdate } from "./products/ProductEditDialogs";
 import type { GcTcpView, WorkspaceAnalysis } from "./types";
 
 const pdfMakeWithVfs = pdfMake as unknown as { vfs?: typeof pdfFonts.vfs };
@@ -513,8 +514,11 @@ export const TercerosView: FC<{ workspace: CloudWorkspaceEntry }> = ({
 export const CatalogosView: FC<{
   workspace: CloudWorkspaceEntry;
   deletingProduct: boolean;
+  savingProductChanges: boolean;
   onDeleteProduct: (productId: string) => void;
-}> = ({ workspace, deletingProduct, onDeleteProduct }) => {
+  onUpdateProductPrice: (payload: ProductPriceUpdate) => void;
+  onUpdateProductStock: (payload: ProductStockUpdate) => void;
+}> = ({ workspace, deletingProduct, savingProductChanges, onDeleteProduct, onUpdateProductPrice, onUpdateProductStock }) => {
   const cuentas = workspace.accounting.cuentasContables;
 
   return (
@@ -554,7 +558,10 @@ export const CatalogosView: FC<{
       <ProductCatalogPanel
         workspace={workspace}
         deletingProduct={deletingProduct}
+        savingProductChanges={savingProductChanges}
         onDeleteProduct={onDeleteProduct}
+        onUpdateProductPrice={onUpdateProductPrice}
+        onUpdateProductStock={onUpdateProductStock}
       />
     </div>
   );

--- a/client/src/gctcp/views.tsx
+++ b/client/src/gctcp/views.tsx
@@ -174,7 +174,12 @@ export const EntriesView: FC<{
   return (
     <Card className="rounded-lg shadow-sm">
       <CardHeader className="flex-row items-center justify-between gap-3 p-4">
-        <CardTitle className="text-base">{label} por mes</CardTitle>
+        <div>
+          <CardTitle className="text-base">{label} por mes</CardTitle>
+          <p className="text-xs text-slate-500 dark:text-slate-400">
+            Año fiscal {workspace.registro.generales.anio}
+          </p>
+        </div>
         <Badge variant="outline">{workspace.name}</Badge>
       </CardHeader>
       <CardContent className="p-4 pt-0">


### PR DESCRIPTION
### Motivation
- Mejorar la experiencia en la vista "Cuentas y Productos" permitiendo editar precios y stock sin salir del panel de catálogos. 
- Mostrar información de inventario por almacén para que el usuario vea dónde y cuánto hay disponible. 

### Description
- Añadidos diálogos reutilizables `ProductPriceDialog` y `ProductStockDialog` en `client/src/gctcp/products/ProductEditDialogs.tsx` para editar precio de venta/compra e inventario por almacén. 
- Integrado icono de lápiz y botones de edición en `ProductCatalogPanel` para abrir los diálogos y mostrar disponibilidad por almacén con nombre y cantidad (archivo `client/src/gctcp/products/ProductCatalogPanel.tsx`). 
- Extendido `productUtils` con `getProductStockItems` y cambios en el resumen de precios para exponer valores actuales (`client/src/gctcp/products/productUtils.ts`). 
- Implementada persistencia en el ledger al guardar cambios: funciones `handleUpdateProductPrice`, `handleUpdateProductStock` y `persistProductLedger` actualizan `catalogoVentas`, `catalogoCompras`, `historialPrecios`, `productos` y `stock` en `GC_TCP` y envían `PUT /api/cont-ledger` (`client/src/gctcp/GC_TCP.tsx`). 
- Conectada la vista `CatalogosView` para pasar los callbacks y el flag `savingProductChanges` hacia el panel de productos (`client/src/gctcp/views.tsx`). 

### Testing
- Ejecutado `npm run build` en `client` y la compilación Vite terminó correctamente (advertencia de chunks grandes, sin bloqueo). ✅
- Ejecutado `npx eslint` sobre los archivos modificados (`GC_TCP.tsx`, `views.tsx`, `ProductCatalogPanel.tsx`, `ProductEditDialogs.tsx`, `productUtils.ts`) y pasó para estos cambios. ✅
- Ejecutado `npm run lint` a nivel del proyecto y falló por errores preexistentes en archivos fuera del alcance de esta PR; los errores no fueron introducidos por estos cambios. ❌

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19e18963688322ae55907afefcbfc8)