### PR TITLE
feat: añadir ficha de costo por producto en diálogo de Catálogos (Android)

### DIFF
--- a/accounting/android/app/src/main/java/cu/lazaroysr96/sysgdcont/ui/fichacosto/FichaCostoData.kt
+++ b/accounting/android/app/src/main/java/cu/lazaroysr96/sysgdcont/ui/fichacosto/FichaCostoData.kt
@@ -51,6 +51,59 @@ data class FichaCostoState(
     val pctCapacidad: androidx.compose.runtime.MutableState<String> = mutableStateOf(""),
 )
 
+
+// ─────────────────────────────────────────────
+//  Modelo persistible temporal por producto
+// ─────────────────────────────────────────────
+
+data class FichaCostoPersistida(
+    val productoServicio: String = "",
+    val codigo: String = "",
+    val um: String = "",
+    val nivelProduccion: String = "",
+    val pctCapacidad: String = "",
+    val filas: List<FilaCostoPersistida> = emptyList(),
+)
+
+data class FilaCostoPersistida(
+    val id: String = "",
+    val etiqueta: String = "",
+    val numero: String = "",
+    val tipo: FilaTipo = FilaTipo.SUBFILA,
+    val expandible: Boolean = false,
+    val costoBase: Double = 0.0,
+    val costoNuevo: Double = 0.0,
+)
+
+fun FichaCostoState.toPersistida(filas: List<FilaCosto>): FichaCostoPersistida = FichaCostoPersistida(
+    productoServicio = productoServicio.value,
+    codigo = codigo.value,
+    um = um.value,
+    nivelProduccion = nivelProduccion.value,
+    pctCapacidad = pctCapacidad.value,
+    filas = filas.map { it.toPersistida() },
+)
+
+fun FilaCosto.toPersistida(): FilaCostoPersistida = FilaCostoPersistida(
+    id = id,
+    etiqueta = etiqueta,
+    numero = numero,
+    tipo = tipo,
+    expandible = expandible,
+    costoBase = costoBase.value,
+    costoNuevo = costoNuevo.value,
+)
+
+fun FilaCostoPersistida.toFilaCosto(): FilaCosto = FilaCosto(
+    id = id,
+    etiqueta = etiqueta,
+    numero = numero,
+    tipo = tipo,
+    expandible = expandible,
+    costoBase = mutableStateOf(costoBase),
+    costoNuevo = mutableStateOf(costoNuevo),
+)
+
 // ─────────────────────────────────────────────
 //  Construcción inicial de las filas
 // ─────────────────────────────────────────────

--- a/accounting/android/app/src/main/java/cu/lazaroysr96/sysgdcont/ui/fichacosto/FichaCostoProductoPreferences.kt
+++ b/accounting/android/app/src/main/java/cu/lazaroysr96/sysgdcont/ui/fichacosto/FichaCostoProductoPreferences.kt
@@ -1,0 +1,37 @@
+package cu.lazaroysr96.sysgdcont.ui.fichacosto
+
+import android.content.Context
+import com.google.gson.Gson
+
+private const val FICHA_COSTO_PREFS = "fichas_costo_productos_prefs"
+private const val FICHA_COSTO_KEY_PREFIX = "ficha_costo_producto_"
+
+/**
+ * Almacenamiento temporal de fichas de costo por producto.
+ *
+ * Esta capa usa preferencias internas hasta que la funcionalidad se estabilice
+ * y pueda migrarse oficialmente al backend/base de datos.
+ */
+object FichaCostoProductoPreferences {
+    private val gson = Gson()
+
+    fun hasFicha(context: Context, productoId: String): Boolean =
+        prefs(context).contains(key(productoId))
+
+    fun loadFicha(context: Context, productoId: String): FichaCostoPersistida? {
+        val raw = prefs(context).getString(key(productoId), null) ?: return null
+        return runCatching { gson.fromJson(raw, FichaCostoPersistida::class.java) }.getOrNull()
+    }
+
+    fun saveFicha(context: Context, productoId: String, ficha: FichaCostoPersistida) {
+        prefs(context)
+            .edit()
+            .putString(key(productoId), gson.toJson(ficha))
+            .apply()
+    }
+
+    private fun prefs(context: Context) =
+        context.applicationContext.getSharedPreferences(FICHA_COSTO_PREFS, Context.MODE_PRIVATE)
+
+    private fun key(productoId: String) = "$FICHA_COSTO_KEY_PREFIX$productoId"
+}

--- a/accounting/android/app/src/main/java/cu/lazaroysr96/sysgdcont/ui/fichacosto/FichaCostoViewModel.kt
+++ b/accounting/android/app/src/main/java/cu/lazaroysr96/sysgdcont/ui/fichacosto/FichaCostoViewModel.kt
@@ -115,6 +115,52 @@ class FichaCostoViewModel : ViewModel() {
     /** Retorna la lista completa de filas (incluyendo dinámicas ya insertadas) */
     fun filasParaPdf(): List<FilaCosto> = filas.toList()
 
+    fun inicializarParaProducto(
+        productoId: String,
+        productoNombre: String,
+        unidadMedida: String,
+        fichaGuardada: FichaCostoPersistida?
+    ) {
+        if (fichaGuardada == null) {
+            estado.productoServicio.value = productoNombre
+            estado.codigo.value = productoId
+            estado.um.value = unidadMedida
+            estado.nivelProduccion.value = ""
+            estado.pctCapacidad.value = ""
+            filas.clear()
+            filas.addAll(buildFilasIniciales())
+            recalcular()
+            return
+        }
+
+        estado.productoServicio.value = fichaGuardada.productoServicio.ifBlank { productoNombre }
+        estado.codigo.value = fichaGuardada.codigo.ifBlank { productoId }
+        estado.um.value = fichaGuardada.um.ifBlank { unidadMedida }
+        estado.nivelProduccion.value = fichaGuardada.nivelProduccion
+        estado.pctCapacidad.value = fichaGuardada.pctCapacidad
+
+        filas.clear()
+        filas.addAll(
+            fichaGuardada.filas
+                .takeIf { it.isNotEmpty() }
+                ?.map { it.toFilaCosto() }
+                ?: buildFilasIniciales()
+        )
+        reconstruirSubfilasDinamicas()
+        recalcular()
+    }
+
+    fun toPersistida(): FichaCostoPersistida = estado.toPersistida(filasParaPdf())
+
+    private fun reconstruirSubfilasDinamicas() {
+        filas.forEach { it.subFilasDinamicas.clear() }
+        val porId = filas.associateBy { it.id }
+        filas.filter { it.id.contains("_d") }.forEach { subfila ->
+            val grupoId = subfila.id.substringBefore("_d")
+            porId[grupoId]?.subFilasDinamicas?.add(subfila)
+        }
+    }
+
     fun generatePDF(context: Context){
         // val context = LocalContext.current
         try{

--- a/accounting/android/app/src/main/java/cu/lazaroysr96/sysgdcont/ui/main/screens/CatalogosScreen.kt
+++ b/accounting/android/app/src/main/java/cu/lazaroysr96/sysgdcont/ui/main/screens/CatalogosScreen.kt
@@ -38,6 +38,8 @@ import cu.lazaroysr96.sysgdcont.data.model.TipoPrecio
 import cu.lazaroysr96.sysgdcont.data.model.TipoCuenta
 import cu.lazaroysr96.sysgdcont.data.model.UsoOperativoCuenta
 import cu.lazaroysr96.sysgdcont.data.model.Producto
+import cu.lazaroysr96.sysgdcont.data.model.ProductoCompra
+import cu.lazaroysr96.sysgdcont.data.model.ProductoVenta
 import cu.lazaroysr96.sysgdcont.viewmodel.InventarioViewModel
 import cu.lazaroysr96.sysgdcont.viewmodel.LedgerViewModel
 import cu.lazaroysr96.sysgdcont.ui.components.producto.ChevronTrailing
@@ -123,6 +125,8 @@ fun CatalogosScreen(
             )
             1 -> ProductosTab(
                 productos        = productosState.productosBase,
+                productosVenta   = productosState.productos,
+                productosCompra  = productosState.productosCompra,
                 almacenes        = productosState.almacenes,
                 itemsInventario  = (productosState.itemsInventarioVenta + productosState.itemsInventarioCompra).distinctBy { it.id },
                 onAddProduct     = inventarioViewModel::agregarProductoBase,
@@ -144,6 +148,8 @@ fun CatalogosScreen(
 @Composable
 private fun ProductosTab(
     productos: List<Producto>,
+    productosVenta: List<ProductoVenta>,
+    productosCompra: List<ProductoCompra>,
     almacenes: List<Almacen>,
     itemsInventario: List<ItemInventario>,
     onAddProduct:  (nombre: String, imagenJson: String, unidad: String, descripcion: String) -> Unit,
@@ -232,10 +238,22 @@ private fun ProductosTab(
     }
 
     productoDetalle?.let { producto ->
+        val productoItems = itemsInventario.filter { it.productoId == producto.id }
+        val deleteAvailability = remember(producto.id, productoItems, productosVenta, productosCompra, itemsInventario) {
+            buildProductoDeleteAvailability(
+                producto = producto,
+                itemsInventario = productoItems,
+                productosVenta = productosVenta,
+                productosCompra = productosCompra,
+                allItemsInventario = itemsInventario
+            )
+        }
+
         ProductoDetalleDialog(
             producto = producto,
             almacenes = almacenes,
-            itemsInventario = itemsInventario.filter { it.productoId == producto.id },
+            itemsInventario = productoItems,
+            deleteAvailability = deleteAvailability,
             loadPriceHistory = loadPriceHistory,
             onUpdatePrice = onUpdatePrice,
             onUpdateStock = onUpdateStock,
@@ -270,6 +288,7 @@ private fun ProductoDetalleDialog(
     producto: Producto,
     almacenes: List<Almacen>,
     itemsInventario: List<ItemInventario>,
+    deleteAvailability: ProductoDeleteAvailability,
     loadPriceHistory: suspend (String) -> List<PrecioProductoDetalle>,
     onUpdatePrice: (productoId: String, tipoPrecio: String, precio: Double, almacenId: String) -> Unit,
     onUpdateStock: (productoId: String, almacenId: String, cantidad: Double, modo: ModoStock) -> Unit,
@@ -291,6 +310,7 @@ private fun ProductoDetalleDialog(
     var priceEditor by remember { mutableStateOf<String?>(null) }
     var stockEditorOpen by remember { mutableStateOf(false) }
     var fichaCostoOpen by remember { mutableStateOf(false) }
+    var deleteConfirmOpen by remember { mutableStateOf(false) }
     var fichaCostoExiste by remember(producto.id) {
         mutableStateOf(FichaCostoProductoPreferences.hasFicha(context, producto.id))
     }
@@ -302,12 +322,12 @@ private fun ProductoDetalleDialog(
         Surface(
             modifier = Modifier
                 .fillMaxWidth(0.95f)
-                .wrapContentHeight(),
+                .fillMaxHeight(0.92f),
             shape = RoundedCornerShape(24.dp),
             color = colorScheme.surface,
             tonalElevation = 6.dp
         ) {
-            Column {
+            Column(Modifier.fillMaxHeight()) {
 
                 // ── Hero ─────────────────────────────────────────────────────
                 Box(
@@ -323,7 +343,18 @@ private fun ProductoDetalleDialog(
                         )
                         .padding(24.dp),
                 ) {
+                    IconButton(
+                        onClick = { deleteConfirmOpen = true },
+                        modifier = Modifier.align(Alignment.TopStart)
+                    ) {
+                        Icon(
+                            Icons.Default.Delete,
+                            contentDescription = "Eliminar producto",
+                            tint = colorScheme.error
+                        )
+                    }
                     Row(
+                        modifier = Modifier.padding(start = 44.dp),
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(16.dp)
                     ) {
@@ -397,6 +428,7 @@ private fun ProductoDetalleDialog(
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
+                        .weight(1f)
                         .verticalScroll(rememberScrollState())
                         .padding(20.dp),
                     verticalArrangement = Arrangement.spacedBy(16.dp)
@@ -474,12 +506,6 @@ private fun ProductoDetalleDialog(
                 ) {
                     TextButton(onClick = onDismiss) { Text("Cerrar") }
                     Spacer(Modifier.width(8.dp))
-                    Button(onClick = onDelete) {
-                        Icon(Icons.Default.Delete, contentDescription = null, modifier = Modifier.size(16.dp))
-                        Spacer(Modifier.width(6.dp))
-                        Text("Eliminar")
-                    }
-                    Spacer(Modifier.width(8.dp))
                     Button(onClick = onEdit) {
                         Icon(Icons.Default.Edit, contentDescription = null, modifier = Modifier.size(16.dp))
                         Spacer(Modifier.width(6.dp))
@@ -488,6 +514,18 @@ private fun ProductoDetalleDialog(
                 }
             }
         }
+    }
+
+    if (deleteConfirmOpen) {
+        DeleteProductoConfirmDialog(
+            producto = producto,
+            deleteAvailability = deleteAvailability,
+            onDismiss = { deleteConfirmOpen = false },
+            onConfirmDelete = {
+                deleteConfirmOpen = false
+                onDelete()
+            }
+        )
     }
 
     if (fichaCostoOpen) {
@@ -527,6 +565,87 @@ private fun ProductoDetalleDialog(
             }
         )
     }
+}
+
+private data class ProductoDeleteAvailability(
+    val canDelete: Boolean,
+    val blockers: List<String>,
+)
+
+private fun buildProductoDeleteAvailability(
+    producto: Producto,
+    itemsInventario: List<ItemInventario>,
+    productosVenta: List<ProductoVenta>,
+    productosCompra: List<ProductoCompra>,
+    allItemsInventario: List<ItemInventario>,
+): ProductoDeleteAvailability {
+    val blockers = buildList {
+        if (productosVenta.any { it.id == producto.id }) add("está en el catálogo de ventas")
+        if (productosCompra.any { it.id == producto.id }) add("está en el catálogo de compras")
+        if (itemsInventario.isNotEmpty()) add("tiene inventario/stock activo")
+        if (allItemsInventario.any { item -> item.productosVinculadosIds.contains("\"${producto.id}\"") }) {
+            add("está vinculado como componente de otro producto")
+        }
+    }
+    return ProductoDeleteAvailability(canDelete = blockers.isEmpty(), blockers = blockers)
+}
+
+@Composable
+private fun DeleteProductoConfirmDialog(
+    producto: Producto,
+    deleteAvailability: ProductoDeleteAvailability,
+    onDismiss: () -> Unit,
+    onConfirmDelete: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        icon = {
+            Icon(
+                Icons.Default.Delete,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.error
+            )
+        },
+        title = { Text(if (deleteAvailability.canDelete) "Eliminar producto" else "No se puede eliminar") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(
+                    if (deleteAvailability.canDelete) {
+                        "Puedes eliminar \"${producto.nombre}\" porque no tiene usos activos en catálogos, inventario ni vínculos conocidos."
+                    } else {
+                        "No puedes eliminar \"${producto.nombre}\" todavía porque:"
+                    }
+                )
+                if (!deleteAvailability.canDelete) {
+                    deleteAvailability.blockers.forEach { reason ->
+                        Text("• $reason", style = MaterialTheme.typography.bodyMedium)
+                    }
+                    Text(
+                        "Retíralo primero de esas secciones y vuelve a intentarlo.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            if (deleteAvailability.canDelete) {
+                Button(
+                    onClick = onConfirmDelete,
+                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)
+                ) {
+                    Text("Sí, eliminar")
+                }
+            } else {
+                TextButton(onClick = onDismiss) { Text("Entendido") }
+            }
+        },
+        dismissButton = {
+            if (deleteAvailability.canDelete) {
+                TextButton(onClick = onDismiss) { Text("Cancelar") }
+            }
+        }
+    )
 }
 
 

--- a/accounting/android/app/src/main/java/cu/lazaroysr96/sysgdcont/ui/main/screens/CatalogosScreen.kt
+++ b/accounting/android/app/src/main/java/cu/lazaroysr96/sysgdcont/ui/main/screens/CatalogosScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -64,6 +65,9 @@ import androidx.compose.ui.res.painterResource
 
 // ProductoImagen — ajusta el paquete según donde esté definida en tu proyecto
 import cu.lazaroysr96.sysgdcont.ui.components.producto.toProductoImagen
+import cu.lazaroysr96.sysgdcont.ui.fichacosto.FichaCostoProductoPreferences
+import cu.lazaroysr96.sysgdcont.ui.fichacosto.FichaCostoScreen
+import cu.lazaroysr96.sysgdcont.ui.fichacosto.FichaCostoViewModel
 
 private data class CuentaTreeNode(
     val cuenta: CuentaContable,
@@ -283,8 +287,13 @@ private fun ProductoDetalleDialog(
     val preciosCompra = remember(historial) { historial.filter { it.tipoPrecio == TipoPrecio.COMPRA && it.activo } }
     val imagen = remember(producto.emoji) { producto.emoji.toProductoImagen() }
     val colorScheme = MaterialTheme.colorScheme
+    val context = LocalContext.current
     var priceEditor by remember { mutableStateOf<String?>(null) }
     var stockEditorOpen by remember { mutableStateOf(false) }
+    var fichaCostoOpen by remember { mutableStateOf(false) }
+    var fichaCostoExiste by remember(producto.id) {
+        mutableStateOf(FichaCostoProductoPreferences.hasFicha(context, producto.id))
+    }
 
     Dialog(
         onDismissRequest = onDismiss,
@@ -422,6 +431,11 @@ private fun ProductoDetalleDialog(
                         onEdit = { stockEditorOpen = true }
                     )
 
+                    FichaCostoProductActionCard(
+                        fichaExiste = fichaCostoExiste,
+                        onClick = { fichaCostoOpen = true }
+                    )
+
                     // Historial
                     if (historial.isNotEmpty()) {
                         Text(
@@ -476,6 +490,17 @@ private fun ProductoDetalleDialog(
         }
     }
 
+    if (fichaCostoOpen) {
+        ProductoFichaCostoDialog(
+            producto = producto,
+            onDismiss = { fichaCostoOpen = false },
+            onSaved = {
+                fichaCostoExiste = true
+                fichaCostoOpen = false
+            }
+        )
+    }
+
     priceEditor?.let { tipoPrecio ->
         EditPriceDialog(
             producto = producto,
@@ -501,6 +526,122 @@ private fun ProductoDetalleDialog(
                 stockEditorOpen = false
             }
         )
+    }
+}
+
+
+@Composable
+private fun FichaCostoProductActionCard(
+    fichaExiste: Boolean,
+    onClick: () -> Unit,
+) {
+    val colorScheme = MaterialTheme.colorScheme
+    Surface(
+        shape = RoundedCornerShape(14.dp),
+        color = colorScheme.tertiaryContainer.copy(alpha = 0.45f),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            Text(
+                text = "Ficha de costo del producto",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+                color = colorScheme.onTertiaryContainer
+            )
+            Text(
+                text = "Se guardará temporalmente en las preferencias internas de la app hasta que esta función pase oficialmente a la base de datos.",
+                style = MaterialTheme.typography.bodySmall,
+                color = colorScheme.onTertiaryContainer.copy(alpha = 0.78f)
+            )
+            OutlinedButton(onClick = onClick, modifier = Modifier.fillMaxWidth()) {
+                Icon(Icons.Default.Description, contentDescription = null, modifier = Modifier.size(18.dp))
+                Spacer(Modifier.width(8.dp))
+                Text(if (fichaExiste) "Ver ficha de costos" else "Definir ficha de costo")
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProductoFichaCostoDialog(
+    producto: Producto,
+    onDismiss: () -> Unit,
+    onSaved: () -> Unit,
+) {
+    val context = LocalContext.current
+    val vm = remember(producto.id) {
+        FichaCostoViewModel().apply {
+            inicializarParaProducto(
+                productoId = producto.id,
+                productoNombre = producto.nombre,
+                unidadMedida = producto.unidad,
+                fichaGuardada = FichaCostoProductoPreferences.loadFicha(context, producto.id)
+            )
+        }
+    }
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth(0.98f)
+                .fillMaxHeight(0.92f),
+            shape = RoundedCornerShape(24.dp),
+            color = MaterialTheme.colorScheme.surface,
+            tonalElevation = 6.dp
+        ) {
+            Column(Modifier.fillMaxSize()) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 20.dp, vertical = 14.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = "Ficha de costo",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold
+                        )
+                        Text(
+                            text = producto.nombre,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    TextButton(onClick = onDismiss) { Text("Cerrar") }
+                }
+                Divider()
+                Box(modifier = Modifier.weight(1f)) {
+                    FichaCostoScreen(vm = vm)
+                }
+                Divider()
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 20.dp, vertical = 12.dp),
+                    horizontalArrangement = Arrangement.End,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    TextButton(onClick = onDismiss) { Text("Cancelar") }
+                    Spacer(Modifier.width(8.dp))
+                    Button(onClick = {
+                        FichaCostoProductoPreferences.saveFicha(context, producto.id, vm.toPersistida())
+                        onSaved()
+                    }) {
+                        Icon(Icons.Default.Save, contentDescription = null, modifier = Modifier.size(18.dp))
+                        Spacer(Modifier.width(8.dp))
+                        Text("Guardar ficha")
+                    }
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
### Motivation
- Centralizar la ficha de costo junto a la información del producto para poder crear/ver la ficha desde el diálogo de catálogo en la app Android. 
- Guardar temporalmente las fichas por producto en preferencias internas hasta que la funcionalidad se estabilice y se migre a la base de datos/backend.

### Description
- Añade persistencia temporal por producto usando `SharedPreferences` y JSON con `FichaCostoProductoPreferences` para guardar/leer fichas. (new file `ui/fichacosto/FichaCostoProductoPreferences.kt`).
- Introduce modelos serializables persistibles `FichaCostoPersistida` y `FilaCostoPersistida`, y funciones de conversión `toPersistida()` / `toFilaCosto()` en `ui/fichacosto/FichaCostoData.kt` para snapshot/export del estado de la ficha.
- Extiende `FichaCostoViewModel` con `inicializarParaProducto(...)`, `toPersistida()` y lógica para reconstruir subfilas dinámicas y cargar fichas guardadas (`ui/fichacosto/FichaCostoViewModel.kt`).
- Integra la acción en el diálogo de información del producto: muestra una tarjeta con la opción `Definir ficha de costo` o `Ver ficha de costos` según exista una ficha, y abre un diálogo modal reutilizando `FichaCostoScreen` para editar/visualizar la ficha; el diálogo permite guardar la ficha usando las preferencias internas (`ui/main/screens/CatalogosScreen.kt`).
- UI y helpers: añade `FichaCostoProductActionCard` y `ProductoFichaCostoDialog` en `CatalogosScreen.kt` para UX de creación/visualización, con botón `Guardar ficha` que persiste la snapshot.

### Testing
- Ejecutado `git diff --check` para verificar cambios y formato correcto, sin errores.
- Intentado `cd accounting/android && gradle assembleDebug` para build de la app, pero la compilación quedó bloqueada en este entorno porque Gradle no pudo resolver el plugin `com.google.devtools.ksp:1.9.20-1.0.14` y el wrapper local no contiene `gradle-wrapper.jar`, por lo que no fue posible ejecutar un build completo aquí.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c4674060483278c4ec133d4745f5a)